### PR TITLE
Add Python to editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -8,5 +8,8 @@ indent_style = space
 insert_final_newline = true
 trim_trailing_whitespace = true
 
+[*.py]
+indent_size = 4
+
 [*.md]
 indent_size = unset


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes a small change to the `.editorconfig` file. The change specifies the `indent_size` for Python files to be 4 spaces.

* [`.editorconfig`](diffhunk://#diff-0947e2727d6bad8cd0ac4122f5314bb5b04e337393075bc4b5ef143b17fcbd5bR11-R13): Added `indent_size = 4` for Python files.

Fixes #19
