### PR TITLE
Add Scanner Justfile

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -1,3 +1,5 @@
+mod scanner 'scanner/scanner.just'
+
 # ------------------------------------------------------------------------------
 # Prettier
 # ------------------------------------------------------------------------------
@@ -17,10 +19,12 @@ prettier-format:
 # Format Justfile
 format:
     just --fmt --unstable
+    just --fmt --unstable --justfile scanner/scanner.just
 
 # Check Justfile formatting
 format-check:
     just --fmt --check --unstable
+    just --fmt --check --unstable --justfile scanner/scanner.just
 
 # ------------------------------------------------------------------------------
 # Gitleaks

--- a/scanner/scanner.just
+++ b/scanner/scanner.just
@@ -1,0 +1,27 @@
+# ------------------------------------------------------------------------------
+# Common Commands
+# ------------------------------------------------------------------------------
+
+# Install python dependencies
+install:
+    uv sync --all-extras
+
+# Run the analyser
+run:
+    uv run python -m main.py
+
+# Run the analyser with default values
+run-with-defaults:
+    INPUT_DEBUG=true INPUT_REPOSITORY_OWNER=JackPlowman uv run python main.py
+
+# ------------------------------------------------------------------------------
+# Test Commands
+# ------------------------------------------------------------------------------
+
+# Run unit tests
+unit-test:
+    uv run pytest . --cov=. --cov-report=xml
+
+# Run unit tests with debug output
+unit-test-debug:
+    uv run pytest . --cov=. --cov-report=xml -vvvv


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes changes to the `Justfile` and the addition of a new `scanner/scanner.just` file to manage commands related to the scanner module. The most important changes include adding a new module to the `Justfile`, updating the formatting commands to include the new module, and defining several commands in the new `scanner/scanner.just` file.

Updates to `Justfile`:

* Added the `scanner` module to the `Justfile` for better organization of scanner-related commands.
* Updated the `format` and `format-check` commands to include formatting for the new `scanner/scanner.just` file.

New `scanner/scanner.just` file:

* Added common commands for installing Python dependencies, running the analyzer, and running the analyzer with default values.
* Added test commands for running unit tests and running unit tests with debug output.

Fixes #33
