### PR TITLE
Add Scanner Python Linting Job

### DIFF
--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -145,3 +145,46 @@ jobs:
           config-file: .github/other-configurations/codeql-config.yml
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v3.28.10
+
+  run-scanner-python-code-checks:
+    name: Run Scanner Python Code Checks
+    runs-on: ubuntu-latest
+    permissions:
+      statuses: write
+      security-events: write
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4.2.2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Install Python and UV
+        uses: astral-sh/setup-uv@v5.3.1
+        with:
+          pyproject-file: "pyproject.toml"
+          enable-cache: true
+      - name: Set up Just
+        uses: extractions/setup-just@v2
+      - name: Install Python Dependencies
+        run: just scanner::install
+      - name: Generate Ruff Sarif
+        run: just scanner::ruff-lint-check
+        env:
+          RUFF_OUTPUT_FORMAT: "sarif"
+          RUFF_OUTPUT_FILE: "ruff-results.sarif"
+        continue-on-error: true
+      - name: Upload Ruff analysis results to GitHub
+        uses: github/codeql-action/upload-sarif@v3.28.10
+        with:
+          sarif_file: scanner/ruff-results.sarif
+          wait-for-processing: true
+      - name: Check Python Code Format (Ruff)
+        run: just scanner::ruff-format-check
+        env:
+          RUFF_OUTPUT_FORMAT: "github"
+      - name: Check Python Code Linting (Ruff)
+        run: just scanner::ruff-lint-check
+        env:
+          RUFF_OUTPUT_FORMAT: "github"
+      - name: Check Python Code for Dead Code (Vulture)
+        run: just scanner::vulture

--- a/scanner/pyproject.toml
+++ b/scanner/pyproject.toml
@@ -9,7 +9,8 @@ dependencies = [
 
 [project.optional-dependencies]
 dev = [
-  "ruff==0.9.10"
+  "ruff==0.9.10",
+  "vulture==2.14",
 ]
 
 [tool.uv]
@@ -64,3 +65,6 @@ convention = "google"
 
 [tool.ruff.lint.isort]
 known-first-party = ["scanner"]
+
+[tool.vulture]
+exclude = [".venv"]

--- a/scanner/scanner.just
+++ b/scanner/scanner.just
@@ -56,3 +56,11 @@ ruff-format-check:
 # Fix Ruff format issues
 ruff-format-fix:
     uv run ruff format .
+
+# ------------------------------------------------------------------------------
+# Other Python Tools
+# ------------------------------------------------------------------------------
+
+# Check for unused code
+vulture:
+    uv run vulture .

--- a/scanner/uv.lock
+++ b/scanner/uv.lock
@@ -246,6 +246,7 @@ dependencies = [
 [package.optional-dependencies]
 dev = [
     { name = "ruff" },
+    { name = "vulture" },
 ]
 
 [package.metadata]
@@ -253,6 +254,7 @@ requires-dist = [
     { name = "gitpython", specifier = "==3.1.44" },
     { name = "pygithub", specifier = "==2.6.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = "==0.9.10" },
+    { name = "vulture", marker = "extra == 'dev'", specifier = "==2.14" },
 ]
 provides-extras = ["dev"]
 
@@ -281,6 +283,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/aa/63/e53da845320b757bf29ef6a9062f5c669fe997973f966045cb019c3f4b66/urllib3-2.3.0.tar.gz", hash = "sha256:f8c5449b3cf0861679ce7e0503c7b44b5ec981bec0d1d3795a07f1ba96f0204d", size = 307268 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c8/19/4ec628951a74043532ca2cf5d97b7b14863931476d117c471e8e2b1eb39f/urllib3-2.3.0-py3-none-any.whl", hash = "sha256:1cee9ad369867bfdbbb48b7dd50374c0967a0bb7710050facf0dd6911440e3df", size = 128369 },
+]
+
+[[package]]
+name = "vulture"
+version = "2.14"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8e/25/925f35db758a0f9199113aaf61d703de891676b082bd7cf73ea01d6000f7/vulture-2.14.tar.gz", hash = "sha256:cb8277902a1138deeab796ec5bef7076a6e0248ca3607a3f3dee0b6d9e9b8415", size = 58823 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/56/0cc15b8ff2613c1d5c3dc1f3f576ede1c43868c1bc2e5ccaa2d4bcd7974d/vulture-2.14-py2.py3-none-any.whl", hash = "sha256:d9a90dba89607489548a49d557f8bac8112bd25d3cbc8aeef23e860811bd5ed9", size = 28915 },
 ]
 
 [[package]]


### PR DESCRIPTION
# Pull Request

## Description

This pull request introduces several changes to enhance the Python code checks and linting processes in the project. The primary updates include adding a new GitHub workflow for running Python code checks, updating the `pyproject.toml` configuration, and adding a new command in the `scanner.just` file.

Enhancements to Python code checks:

* [`.github/workflows/code-checks.yml`](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4R148-R190): Added a new job `run-scanner-python-code-checks` to perform various Python code checks, including Ruff linting, formatting, and dead code detection using Vulture.

Configuration updates:

* [`scanner/pyproject.toml`](diffhunk://#diff-a3b82d49d76ebad61ba78436003c53e4907ae972476a9531807ceabd157d7586L12-R13): Updated the `dev` optional dependencies to include `vulture` for dead code detection.
* [`scanner/pyproject.toml`](diffhunk://#diff-a3b82d49d76ebad61ba78436003c53e4907ae972476a9531807ceabd157d7586R68-R70): Added a new `[tool.vulture]` section to exclude the `.venv` directory from Vulture analysis.

New command additions:

* [`scanner/scanner.just`](diffhunk://#diff-3205dc7246237ab9f796a373b98d2390f8b03bc04ea76a8eb831ba83b55ee538R59-R66): Added a new command `vulture` to check for unused code using Vulture.

Fixes #37
