### PR TITLE
Add Diagram Linting and Formatting Workflow

### DIFF
--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -197,3 +197,44 @@ jobs:
           RUFF_OUTPUT_FORMAT: "github"
       - name: Check Python Code for Dead Code (Vulture)
         run: just scanner::vulture
+
+  run-diagrams-python-code-checks:
+    name: Run Diagrams Python Code Checks
+    runs-on: ubuntu-latest
+    permissions:
+      statuses: write
+      security-events: write
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4.2.2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Install Python and UV
+        uses: astral-sh/setup-uv@v5.3.1
+        with:
+          pyproject-file: "pyproject.toml"
+          enable-cache: true
+      - name: Set up Just
+        uses: extractions/setup-just@v2
+      - name: Install Python Dependencies
+        run: just diagrams::install
+      - name: Generate Ruff Sarif
+        run: just diagrams::ruff-lint-check
+        env:
+          RUFF_OUTPUT_FORMAT: "sarif"
+          RUFF_OUTPUT_FILE: "ruff-results.sarif"
+        continue-on-error: true
+      - name: Upload Ruff analysis results to GitHub
+        uses: github/codeql-action/upload-sarif@v3.28.10
+        with:
+          sarif_file: diagrams/ruff-results.sarif
+          wait-for-processing: true
+      - name: Check Python Code Format (Ruff)
+        run: just diagrams::ruff-format-check
+        env:
+          RUFF_OUTPUT_FORMAT: "github"
+      - name: Check Python Code Linting (Ruff)
+        run: just diagrams::ruff-lint-check
+        env:
+          RUFF_OUTPUT_FORMAT: "github"

--- a/diagrams/diagrams.just
+++ b/diagrams/diagrams.just
@@ -9,3 +9,34 @@ install:
 # Create the C4 diagram
 create-c4-diagram:
     uv run python c4.py
+
+# ------------------------------------------------------------------------------
+# Ruff - Python Linting and Formatting
+# Set up ruff red-knot when it's ready
+# ------------------------------------------------------------------------------
+
+# Fix all Ruff issues
+ruff-fix:
+    just diagrams::ruff-format-fix
+    just diagrams::ruff-lint-fix
+
+# Check for all Ruff issues
+ruff-checks:
+    just diagrams::ruff-format-check
+    just diagrams::ruff-lint-check
+
+# Check for Ruff issues
+ruff-lint-check:
+    uv run ruff check .
+
+# Fix Ruff lint issues
+ruff-lint-fix:
+    uv run ruff check . --fix
+
+# Check for Ruff format issues
+ruff-format-check:
+    uv run ruff format --check .
+
+# Fix Ruff format issues
+ruff-format-fix:
+    uv run ruff format .

--- a/diagrams/pyproject.toml
+++ b/diagrams/pyproject.toml
@@ -63,3 +63,4 @@ convention = "google"
 
 [tool.ruff.lint.isort]
 known-first-party = ["scanner"]
+


### PR DESCRIPTION
# Pull Request

## Description

This pull request introduces new workflows and scripts for running Python code checks specifically for the Diagrams project. The most significant changes include adding a new job in the GitHub Actions workflow, defining new tasks in the `diagrams.just` file, and a minor configuration update in `pyproject.toml`.

### New workflows and scripts for Diagrams project:

* [`.github/workflows/code-checks.yml`](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4R200-R240): Added a new job `run-diagrams-python-code-checks` to run various Python code checks using Ruff, including linting, formatting, and uploading analysis results to GitHub.

* [`diagrams/diagrams.just`](diffhunk://#diff-6d4ef382cb530cc11964abf81b1a9c953f778ccc19c57e9241fb480593b788feR12-R42): Introduced new tasks for Ruff linting and formatting checks and fixes, including `ruff-fix`, `ruff-checks`, `ruff-lint-check`, `ruff-lint-fix`, `ruff-format-check`, and `ruff-format-fix`.

### Configuration update:

* [`diagrams/pyproject.toml`](diffhunk://#diff-72922956af93dcd7c4684bd443145f9049c7ae41910c86826ce0a1f46d04d873R66): Added a blank line for better readability in the `tool.ruff.lint.isort` section.

Fixes #29
