### PR TITLE
Upgrade Ruff Version

### DIFF
--- a/diagrams/pyproject.toml
+++ b/diagrams/pyproject.toml
@@ -8,7 +8,7 @@ dependencies = [
 
 [project.optional-dependencies]
 dev = [
-  "ruff==0.9.10"
+  "ruff==0.10.0"
 ]
 
 [tool.uv]

--- a/diagrams/uv.lock
+++ b/diagrams/uv.lock
@@ -58,7 +58,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "diagrams", specifier = "==0.24.4" },
-    { name = "ruff", marker = "extra == 'dev'", specifier = "==0.9.10" },
+    { name = "ruff", marker = "extra == 'dev'", specifier = "==0.10.0" },
 ]
 provides-extras = ["dev"]
 
@@ -173,27 +173,27 @@ wheels = [
 
 [[package]]
 name = "ruff"
-version = "0.9.10"
+version = "0.10.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/20/8e/fafaa6f15c332e73425d9c44ada85360501045d5ab0b81400076aff27cf6/ruff-0.9.10.tar.gz", hash = "sha256:9bacb735d7bada9cfb0f2c227d3658fc443d90a727b47f206fb33f52f3c0eac7", size = 3759776 }
+sdist = { url = "https://files.pythonhosted.org/packages/4c/ec/9c59d2956566517c98ac8267554f4eaceafb2a19710a429368518b7fab43/ruff-0.10.0.tar.gz", hash = "sha256:fa1554e18deaf8aa097dbcfeafaf38b17a2a1e98fdc18f50e62e8a836abee392", size = 3789921 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/73/b2/af7c2cc9e438cbc19fafeec4f20bfcd72165460fe75b2b6e9a0958c8c62b/ruff-0.9.10-py3-none-linux_armv6l.whl", hash = "sha256:eb4d25532cfd9fe461acc83498361ec2e2252795b4f40b17e80692814329e42d", size = 10049494 },
-    { url = "https://files.pythonhosted.org/packages/6d/12/03f6dfa1b95ddd47e6969f0225d60d9d7437c91938a310835feb27927ca0/ruff-0.9.10-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:188a6638dab1aa9bb6228a7302387b2c9954e455fb25d6b4470cb0641d16759d", size = 10853584 },
-    { url = "https://files.pythonhosted.org/packages/02/49/1c79e0906b6ff551fb0894168763f705bf980864739572b2815ecd3c9df0/ruff-0.9.10-py3-none-macosx_11_0_arm64.whl", hash = "sha256:5284dcac6b9dbc2fcb71fdfc26a217b2ca4ede6ccd57476f52a587451ebe450d", size = 10155692 },
-    { url = "https://files.pythonhosted.org/packages/5b/01/85e8082e41585e0e1ceb11e41c054e9e36fed45f4b210991052d8a75089f/ruff-0.9.10-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:47678f39fa2a3da62724851107f438c8229a3470f533894b5568a39b40029c0c", size = 10369760 },
-    { url = "https://files.pythonhosted.org/packages/a1/90/0bc60bd4e5db051f12445046d0c85cc2c617095c0904f1aa81067dc64aea/ruff-0.9.10-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:99713a6e2766b7a17147b309e8c915b32b07a25c9efd12ada79f217c9c778b3e", size = 9912196 },
-    { url = "https://files.pythonhosted.org/packages/66/ea/0b7e8c42b1ec608033c4d5a02939c82097ddcb0b3e393e4238584b7054ab/ruff-0.9.10-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:524ee184d92f7c7304aa568e2db20f50c32d1d0caa235d8ddf10497566ea1a12", size = 11434985 },
-    { url = "https://files.pythonhosted.org/packages/d5/86/3171d1eff893db4f91755175a6e1163c5887be1f1e2f4f6c0c59527c2bfd/ruff-0.9.10-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:df92aeac30af821f9acf819fc01b4afc3dfb829d2782884f8739fb52a8119a16", size = 12155842 },
-    { url = "https://files.pythonhosted.org/packages/89/9e/700ca289f172a38eb0bca752056d0a42637fa17b81649b9331786cb791d7/ruff-0.9.10-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:de42e4edc296f520bb84954eb992a07a0ec5a02fecb834498415908469854a52", size = 11613804 },
-    { url = "https://files.pythonhosted.org/packages/f2/92/648020b3b5db180f41a931a68b1c8575cca3e63cec86fd26807422a0dbad/ruff-0.9.10-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:d257f95b65806104b6b1ffca0ea53f4ef98454036df65b1eda3693534813ecd1", size = 13823776 },
-    { url = "https://files.pythonhosted.org/packages/5e/a6/cc472161cd04d30a09d5c90698696b70c169eeba2c41030344194242db45/ruff-0.9.10-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b60dec7201c0b10d6d11be00e8f2dbb6f40ef1828ee75ed739923799513db24c", size = 11302673 },
-    { url = "https://files.pythonhosted.org/packages/6c/db/d31c361c4025b1b9102b4d032c70a69adb9ee6fde093f6c3bf29f831c85c/ruff-0.9.10-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:d838b60007da7a39c046fcdd317293d10b845001f38bcb55ba766c3875b01e43", size = 10235358 },
-    { url = "https://files.pythonhosted.org/packages/d1/86/d6374e24a14d4d93ebe120f45edd82ad7dcf3ef999ffc92b197d81cdc2a5/ruff-0.9.10-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:ccaf903108b899beb8e09a63ffae5869057ab649c1e9231c05ae354ebc62066c", size = 9886177 },
-    { url = "https://files.pythonhosted.org/packages/00/62/a61691f6eaaac1e945a1f3f59f1eea9a218513139d5b6c2b8f88b43b5b8f/ruff-0.9.10-py3-none-musllinux_1_2_i686.whl", hash = "sha256:f9567d135265d46e59d62dc60c0bfad10e9a6822e231f5b24032dba5a55be6b5", size = 10864747 },
-    { url = "https://files.pythonhosted.org/packages/ee/94/2c7065e1d92a8a8a46d46d9c3cf07b0aa7e0a1e0153d74baa5e6620b4102/ruff-0.9.10-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:5f202f0d93738c28a89f8ed9eaba01b7be339e5d8d642c994347eaa81c6d75b8", size = 11360441 },
-    { url = "https://files.pythonhosted.org/packages/a7/8f/1f545ea6f9fcd7bf4368551fb91d2064d8f0577b3079bb3f0ae5779fb773/ruff-0.9.10-py3-none-win32.whl", hash = "sha256:bfb834e87c916521ce46b1788fbb8484966e5113c02df216680102e9eb960029", size = 10247401 },
-    { url = "https://files.pythonhosted.org/packages/4f/18/fb703603ab108e5c165f52f5b86ee2aa9be43bb781703ec87c66a5f5d604/ruff-0.9.10-py3-none-win_amd64.whl", hash = "sha256:f2160eeef3031bf4b17df74e307d4c5fb689a6f3a26a2de3f7ef4044e3c484f1", size = 11366360 },
-    { url = "https://files.pythonhosted.org/packages/35/85/338e603dc68e7d9994d5d84f24adbf69bae760ba5efd3e20f5ff2cec18da/ruff-0.9.10-py3-none-win_arm64.whl", hash = "sha256:5fd804c0327a5e5ea26615550e706942f348b197d5475ff34c19733aee4b2e69", size = 10436892 },
+    { url = "https://files.pythonhosted.org/packages/bf/3f/742afe91b43def2a75990b293c676355576c0ff9cdbcf4249f78fa592544/ruff-0.10.0-py3-none-linux_armv6l.whl", hash = "sha256:46a2aa0eaae5048e5f804f0be9489d8a661633e23277b7293089e70d5c1a35c4", size = 10078369 },
+    { url = "https://files.pythonhosted.org/packages/8d/a0/8696fb4862e82f7b40bbbc2917137594b22826cc62d77278a91391507514/ruff-0.10.0-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:775a6bc61af9dd0a2e1763406522a137e62aabb743d8b43ed95f019cdd1526c7", size = 10876912 },
+    { url = "https://files.pythonhosted.org/packages/40/aa/0d48b7b7d7a1f168bb8fd893ed559d633c7d68c4a8ef9b996f0c2bd07aca/ruff-0.10.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:8b03e6fcd39d20f0004f9956f0ed5eadc404d3a299f9d9286323884e3b663730", size = 10229962 },
+    { url = "https://files.pythonhosted.org/packages/21/de/861ced2f75b045d8cfc038d68961d8ac117344df1f43a11abdd05bf7991b/ruff-0.10.0-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:621101d1af80248827f2409a78c8177c8319986a57b4663613b9c72f8617bfcd", size = 10404627 },
+    { url = "https://files.pythonhosted.org/packages/21/69/666e0b840191c3ce433962c0d05fc0f6800afe259ea5d230cc731655d8e2/ruff-0.10.0-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:e2dfe85cb6bfbd4259801e7d4982f2a72bdbd5749dc73a09d68a6dbf77f2209a", size = 9939383 },
+    { url = "https://files.pythonhosted.org/packages/76/bf/34a2adc58092c99cdfa9f1303acd82d840d56412022e477e2ab20c261d2d/ruff-0.10.0-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:43ac3879a20c22fdc57e559f0bb27f0c71828656841d0b42d3505b1e5b3a83c8", size = 11492269 },
+    { url = "https://files.pythonhosted.org/packages/31/3d/f7ccfcf69f15948623b190feea9d411d5029ae39725fcc078f8d43bd07a6/ruff-0.10.0-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:ef5e3aac421bbc62f8a7aab21edd49a359ed42205f7a5091a74386bca1efa293", size = 12186939 },
+    { url = "https://files.pythonhosted.org/packages/6e/3e/c557c0abfdea85c7d238a3cb238c73e7b6d17c30a584234c4fd8fe2cafb6/ruff-0.10.0-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9f4f62d7fac8b748fce67ad308116b4d4cc1a9f964b4804fc5408fbd06e13ba9", size = 11655896 },
+    { url = "https://files.pythonhosted.org/packages/3b/8e/3bfa110f37e5192eb3943f14943d05fbb9a76fea380aa87655e6f6276a54/ruff-0.10.0-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:02f9f6205c5b0d626f98da01a0e75b724a64c21c554bba24b12522c9e9ba6a04", size = 13885502 },
+    { url = "https://files.pythonhosted.org/packages/51/4a/22cdab59b5563dd7f4c504d0f1e6bb25fc800a5a057395bc24f8ff3a85b2/ruff-0.10.0-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:46a97f3d55f68464c48d1e929a8582c7e5bb80ac73336bbc7b0da894d8e6cd9e", size = 11344767 },
+    { url = "https://files.pythonhosted.org/packages/3d/0f/8f85de2ac565f82f47c6d8fb7ae04383e6300560f2d1b91c1268ff91e507/ruff-0.10.0-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:a0b811197d0dc96c13d610f8cfdc56030b405bcff5c2f10eab187b329da0ca4a", size = 10300331 },
+    { url = "https://files.pythonhosted.org/packages/90/4a/b337df327832cb30bd8607e8d1fdf1b6b5ca228307d5008dd49028fb66ae/ruff-0.10.0-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:a13a3fda0870c1c964b47ff5d73805ae80d2a9de93ee2d185d453b8fddf85a84", size = 9926551 },
+    { url = "https://files.pythonhosted.org/packages/d7/e9/141233730b85675ac806c4b62f70516bd9c0aae8a55823f3a6589ed411be/ruff-0.10.0-py3-none-musllinux_1_2_i686.whl", hash = "sha256:6ceb8d9f062e90ddcbad929f6136edf764bbf6411420a07e8357602ea28cd99f", size = 10925061 },
+    { url = "https://files.pythonhosted.org/packages/24/09/02987935b55c2d353a226ac1b4f9718830e2e195834929f46c07eeede746/ruff-0.10.0-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:c41d07d573617ed2f287ea892af2446fd8a8d877481e8e1ba6928e020665d240", size = 11394949 },
+    { url = "https://files.pythonhosted.org/packages/d6/ec/054f9879fb6f4122d43ffe5c9f88c8c323a9cd14220d5c813aea5805e02c/ruff-0.10.0-py3-none-win32.whl", hash = "sha256:76e2de0cbdd587e373cd3b4050d2c45babdd7014c1888a6f121c29525c748a15", size = 10272077 },
+    { url = "https://files.pythonhosted.org/packages/6e/49/915d8682f24645b904fe6a1aac36101464fc814923fdf293c1388dc5533c/ruff-0.10.0-py3-none-win_amd64.whl", hash = "sha256:f943acdecdcc6786a8d1dad455dd9f94e6d57ccc115be4993f9b52ef8316027a", size = 11393300 },
+    { url = "https://files.pythonhosted.org/packages/82/ed/5c59941634c9026ceeccc7c119f23f4356f09aafd28c15c1bc734ac66b01/ruff-0.10.0-py3-none-win_arm64.whl", hash = "sha256:935a943bdbd9ff0685acd80d484ea91088e27617537b5f7ef8907187d19d28d0", size = 10510133 },
 ]
 
 [[package]]

--- a/scanner/pyproject.toml
+++ b/scanner/pyproject.toml
@@ -12,9 +12,9 @@ dependencies = [
 dev = [
   "pytest==8.3.5",
   "pytest-cov==6.0.0",
-  "ruff==0.9.10",
+  "ruff==0.10.0",
   "vulture==2.14",
-  "zizmor==1.5.0",
+  "zizmor==1.5.1",
 ]
 
 [tool.uv]

--- a/scanner/uv.lock
+++ b/scanner/uv.lock
@@ -305,27 +305,27 @@ wheels = [
 
 [[package]]
 name = "ruff"
-version = "0.9.10"
+version = "0.10.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/20/8e/fafaa6f15c332e73425d9c44ada85360501045d5ab0b81400076aff27cf6/ruff-0.9.10.tar.gz", hash = "sha256:9bacb735d7bada9cfb0f2c227d3658fc443d90a727b47f206fb33f52f3c0eac7", size = 3759776 }
+sdist = { url = "https://files.pythonhosted.org/packages/4c/ec/9c59d2956566517c98ac8267554f4eaceafb2a19710a429368518b7fab43/ruff-0.10.0.tar.gz", hash = "sha256:fa1554e18deaf8aa097dbcfeafaf38b17a2a1e98fdc18f50e62e8a836abee392", size = 3789921 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/73/b2/af7c2cc9e438cbc19fafeec4f20bfcd72165460fe75b2b6e9a0958c8c62b/ruff-0.9.10-py3-none-linux_armv6l.whl", hash = "sha256:eb4d25532cfd9fe461acc83498361ec2e2252795b4f40b17e80692814329e42d", size = 10049494 },
-    { url = "https://files.pythonhosted.org/packages/6d/12/03f6dfa1b95ddd47e6969f0225d60d9d7437c91938a310835feb27927ca0/ruff-0.9.10-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:188a6638dab1aa9bb6228a7302387b2c9954e455fb25d6b4470cb0641d16759d", size = 10853584 },
-    { url = "https://files.pythonhosted.org/packages/02/49/1c79e0906b6ff551fb0894168763f705bf980864739572b2815ecd3c9df0/ruff-0.9.10-py3-none-macosx_11_0_arm64.whl", hash = "sha256:5284dcac6b9dbc2fcb71fdfc26a217b2ca4ede6ccd57476f52a587451ebe450d", size = 10155692 },
-    { url = "https://files.pythonhosted.org/packages/5b/01/85e8082e41585e0e1ceb11e41c054e9e36fed45f4b210991052d8a75089f/ruff-0.9.10-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:47678f39fa2a3da62724851107f438c8229a3470f533894b5568a39b40029c0c", size = 10369760 },
-    { url = "https://files.pythonhosted.org/packages/a1/90/0bc60bd4e5db051f12445046d0c85cc2c617095c0904f1aa81067dc64aea/ruff-0.9.10-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:99713a6e2766b7a17147b309e8c915b32b07a25c9efd12ada79f217c9c778b3e", size = 9912196 },
-    { url = "https://files.pythonhosted.org/packages/66/ea/0b7e8c42b1ec608033c4d5a02939c82097ddcb0b3e393e4238584b7054ab/ruff-0.9.10-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:524ee184d92f7c7304aa568e2db20f50c32d1d0caa235d8ddf10497566ea1a12", size = 11434985 },
-    { url = "https://files.pythonhosted.org/packages/d5/86/3171d1eff893db4f91755175a6e1163c5887be1f1e2f4f6c0c59527c2bfd/ruff-0.9.10-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:df92aeac30af821f9acf819fc01b4afc3dfb829d2782884f8739fb52a8119a16", size = 12155842 },
-    { url = "https://files.pythonhosted.org/packages/89/9e/700ca289f172a38eb0bca752056d0a42637fa17b81649b9331786cb791d7/ruff-0.9.10-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:de42e4edc296f520bb84954eb992a07a0ec5a02fecb834498415908469854a52", size = 11613804 },
-    { url = "https://files.pythonhosted.org/packages/f2/92/648020b3b5db180f41a931a68b1c8575cca3e63cec86fd26807422a0dbad/ruff-0.9.10-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:d257f95b65806104b6b1ffca0ea53f4ef98454036df65b1eda3693534813ecd1", size = 13823776 },
-    { url = "https://files.pythonhosted.org/packages/5e/a6/cc472161cd04d30a09d5c90698696b70c169eeba2c41030344194242db45/ruff-0.9.10-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b60dec7201c0b10d6d11be00e8f2dbb6f40ef1828ee75ed739923799513db24c", size = 11302673 },
-    { url = "https://files.pythonhosted.org/packages/6c/db/d31c361c4025b1b9102b4d032c70a69adb9ee6fde093f6c3bf29f831c85c/ruff-0.9.10-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:d838b60007da7a39c046fcdd317293d10b845001f38bcb55ba766c3875b01e43", size = 10235358 },
-    { url = "https://files.pythonhosted.org/packages/d1/86/d6374e24a14d4d93ebe120f45edd82ad7dcf3ef999ffc92b197d81cdc2a5/ruff-0.9.10-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:ccaf903108b899beb8e09a63ffae5869057ab649c1e9231c05ae354ebc62066c", size = 9886177 },
-    { url = "https://files.pythonhosted.org/packages/00/62/a61691f6eaaac1e945a1f3f59f1eea9a218513139d5b6c2b8f88b43b5b8f/ruff-0.9.10-py3-none-musllinux_1_2_i686.whl", hash = "sha256:f9567d135265d46e59d62dc60c0bfad10e9a6822e231f5b24032dba5a55be6b5", size = 10864747 },
-    { url = "https://files.pythonhosted.org/packages/ee/94/2c7065e1d92a8a8a46d46d9c3cf07b0aa7e0a1e0153d74baa5e6620b4102/ruff-0.9.10-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:5f202f0d93738c28a89f8ed9eaba01b7be339e5d8d642c994347eaa81c6d75b8", size = 11360441 },
-    { url = "https://files.pythonhosted.org/packages/a7/8f/1f545ea6f9fcd7bf4368551fb91d2064d8f0577b3079bb3f0ae5779fb773/ruff-0.9.10-py3-none-win32.whl", hash = "sha256:bfb834e87c916521ce46b1788fbb8484966e5113c02df216680102e9eb960029", size = 10247401 },
-    { url = "https://files.pythonhosted.org/packages/4f/18/fb703603ab108e5c165f52f5b86ee2aa9be43bb781703ec87c66a5f5d604/ruff-0.9.10-py3-none-win_amd64.whl", hash = "sha256:f2160eeef3031bf4b17df74e307d4c5fb689a6f3a26a2de3f7ef4044e3c484f1", size = 11366360 },
-    { url = "https://files.pythonhosted.org/packages/35/85/338e603dc68e7d9994d5d84f24adbf69bae760ba5efd3e20f5ff2cec18da/ruff-0.9.10-py3-none-win_arm64.whl", hash = "sha256:5fd804c0327a5e5ea26615550e706942f348b197d5475ff34c19733aee4b2e69", size = 10436892 },
+    { url = "https://files.pythonhosted.org/packages/bf/3f/742afe91b43def2a75990b293c676355576c0ff9cdbcf4249f78fa592544/ruff-0.10.0-py3-none-linux_armv6l.whl", hash = "sha256:46a2aa0eaae5048e5f804f0be9489d8a661633e23277b7293089e70d5c1a35c4", size = 10078369 },
+    { url = "https://files.pythonhosted.org/packages/8d/a0/8696fb4862e82f7b40bbbc2917137594b22826cc62d77278a91391507514/ruff-0.10.0-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:775a6bc61af9dd0a2e1763406522a137e62aabb743d8b43ed95f019cdd1526c7", size = 10876912 },
+    { url = "https://files.pythonhosted.org/packages/40/aa/0d48b7b7d7a1f168bb8fd893ed559d633c7d68c4a8ef9b996f0c2bd07aca/ruff-0.10.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:8b03e6fcd39d20f0004f9956f0ed5eadc404d3a299f9d9286323884e3b663730", size = 10229962 },
+    { url = "https://files.pythonhosted.org/packages/21/de/861ced2f75b045d8cfc038d68961d8ac117344df1f43a11abdd05bf7991b/ruff-0.10.0-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:621101d1af80248827f2409a78c8177c8319986a57b4663613b9c72f8617bfcd", size = 10404627 },
+    { url = "https://files.pythonhosted.org/packages/21/69/666e0b840191c3ce433962c0d05fc0f6800afe259ea5d230cc731655d8e2/ruff-0.10.0-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:e2dfe85cb6bfbd4259801e7d4982f2a72bdbd5749dc73a09d68a6dbf77f2209a", size = 9939383 },
+    { url = "https://files.pythonhosted.org/packages/76/bf/34a2adc58092c99cdfa9f1303acd82d840d56412022e477e2ab20c261d2d/ruff-0.10.0-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:43ac3879a20c22fdc57e559f0bb27f0c71828656841d0b42d3505b1e5b3a83c8", size = 11492269 },
+    { url = "https://files.pythonhosted.org/packages/31/3d/f7ccfcf69f15948623b190feea9d411d5029ae39725fcc078f8d43bd07a6/ruff-0.10.0-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:ef5e3aac421bbc62f8a7aab21edd49a359ed42205f7a5091a74386bca1efa293", size = 12186939 },
+    { url = "https://files.pythonhosted.org/packages/6e/3e/c557c0abfdea85c7d238a3cb238c73e7b6d17c30a584234c4fd8fe2cafb6/ruff-0.10.0-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9f4f62d7fac8b748fce67ad308116b4d4cc1a9f964b4804fc5408fbd06e13ba9", size = 11655896 },
+    { url = "https://files.pythonhosted.org/packages/3b/8e/3bfa110f37e5192eb3943f14943d05fbb9a76fea380aa87655e6f6276a54/ruff-0.10.0-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:02f9f6205c5b0d626f98da01a0e75b724a64c21c554bba24b12522c9e9ba6a04", size = 13885502 },
+    { url = "https://files.pythonhosted.org/packages/51/4a/22cdab59b5563dd7f4c504d0f1e6bb25fc800a5a057395bc24f8ff3a85b2/ruff-0.10.0-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:46a97f3d55f68464c48d1e929a8582c7e5bb80ac73336bbc7b0da894d8e6cd9e", size = 11344767 },
+    { url = "https://files.pythonhosted.org/packages/3d/0f/8f85de2ac565f82f47c6d8fb7ae04383e6300560f2d1b91c1268ff91e507/ruff-0.10.0-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:a0b811197d0dc96c13d610f8cfdc56030b405bcff5c2f10eab187b329da0ca4a", size = 10300331 },
+    { url = "https://files.pythonhosted.org/packages/90/4a/b337df327832cb30bd8607e8d1fdf1b6b5ca228307d5008dd49028fb66ae/ruff-0.10.0-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:a13a3fda0870c1c964b47ff5d73805ae80d2a9de93ee2d185d453b8fddf85a84", size = 9926551 },
+    { url = "https://files.pythonhosted.org/packages/d7/e9/141233730b85675ac806c4b62f70516bd9c0aae8a55823f3a6589ed411be/ruff-0.10.0-py3-none-musllinux_1_2_i686.whl", hash = "sha256:6ceb8d9f062e90ddcbad929f6136edf764bbf6411420a07e8357602ea28cd99f", size = 10925061 },
+    { url = "https://files.pythonhosted.org/packages/24/09/02987935b55c2d353a226ac1b4f9718830e2e195834929f46c07eeede746/ruff-0.10.0-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:c41d07d573617ed2f287ea892af2446fd8a8d877481e8e1ba6928e020665d240", size = 11394949 },
+    { url = "https://files.pythonhosted.org/packages/d6/ec/054f9879fb6f4122d43ffe5c9f88c8c323a9cd14220d5c813aea5805e02c/ruff-0.10.0-py3-none-win32.whl", hash = "sha256:76e2de0cbdd587e373cd3b4050d2c45babdd7014c1888a6f121c29525c748a15", size = 10272077 },
+    { url = "https://files.pythonhosted.org/packages/6e/49/915d8682f24645b904fe6a1aac36101464fc814923fdf293c1388dc5533c/ruff-0.10.0-py3-none-win_amd64.whl", hash = "sha256:f943acdecdcc6786a8d1dad455dd9f94e6d57ccc115be4993f9b52ef8316027a", size = 11393300 },
+    { url = "https://files.pythonhosted.org/packages/82/ed/5c59941634c9026ceeccc7c119f23f4356f09aafd28c15c1bc734ac66b01/ruff-0.10.0-py3-none-win_arm64.whl", hash = "sha256:935a943bdbd9ff0685acd80d484ea91088e27617537b5f7ef8907187d19d28d0", size = 10510133 },
 ]
 
 [[package]]
@@ -352,10 +352,10 @@ requires-dist = [
     { name = "pygithub", specifier = "==2.6.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = "==8.3.5" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = "==6.0.0" },
-    { name = "ruff", marker = "extra == 'dev'", specifier = "==0.9.10" },
+    { name = "ruff", marker = "extra == 'dev'", specifier = "==0.10.0" },
     { name = "structlog", specifier = "==25.1.0" },
     { name = "vulture", marker = "extra == 'dev'", specifier = "==2.14" },
-    { name = "zizmor", marker = "extra == 'dev'", specifier = "==1.5.0" },
+    { name = "zizmor", marker = "extra == 'dev'", specifier = "==1.5.1" },
 ]
 provides-extras = ["dev"]
 
@@ -437,22 +437,22 @@ wheels = [
 
 [[package]]
 name = "zizmor"
-version = "1.5.0"
+version = "1.5.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/e6/03/781110d7137a777e1b88bd5826a4421a1e9256b81dde2826ed9168633383/zizmor-1.5.0.tar.gz", hash = "sha256:6945c9ccbf9577b3f9b7359ec0df8c35fb43ea4047058b10f8c2942a8557a0ce", size = 292716 }
+sdist = { url = "https://files.pythonhosted.org/packages/e0/75/c8844f351cae5bc39e46061f439b61c256dd5181cf6fff57532e68008c1c/zizmor-1.5.1.tar.gz", hash = "sha256:a21e9ed724c2048fd7edd6ec70eb89059c314e7ebbb121dc1898c01ad7a7d2ac", size = 292893 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1d/50/c88bff14abf901f6ab220d82548922d931216e8b6371437c782506e90433/zizmor-1.5.0-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:622c0f53a6b8e4e6460c1bea8ead472b81522f1674de6053f8ed87050ffea853", size = 4680458 },
-    { url = "https://files.pythonhosted.org/packages/b2/a4/0374470bfd5ecd191a3f4056a5c5a6ad4ccbc940aa7a74a2b09270eafa1b/zizmor-1.5.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:87add4ede6d88abcdac8262b02479e94f6b0f3e3a3c42f469cace227ddda0685", size = 4424931 },
-    { url = "https://files.pythonhosted.org/packages/d9/b5/4710647feb2451c770de375514074087f9a3f487788a6fdde963e2f534f7/zizmor-1.5.0-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:2118ada233dcdd2773974c434d1299b4c0beed06398da69b4aba192add7e0530", size = 4550282 },
-    { url = "https://files.pythonhosted.org/packages/8d/0b/b3ac29dafa51282cae0c11e1f1dae7ad5b68b4d8fe0392c076e1f7baa14e/zizmor-1.5.0-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:097c0b811b913ba9feb57d98218380e17b9b578c73968f7b0b3ab15369bb4d04", size = 4699348 },
-    { url = "https://files.pythonhosted.org/packages/32/5d/602b491c0294f3a0fdb24683a64d3c092f86593b0c97621e66a445cbe775/zizmor-1.5.0-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:c35551f1e72b6135c83df45da8be1240b62677168847cbb11568c1ffbd39378e", size = 4997571 },
-    { url = "https://files.pythonhosted.org/packages/0e/f4/d4b665cd41ed22f3a5e51a249492bcd8b17729a1e27da48214f4a204b4c1/zizmor-1.5.0-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:dfe96f6fd140bc4cfeb044b31521772294a62fd009de5f9515575c77315eccc8", size = 6058089 },
-    { url = "https://files.pythonhosted.org/packages/79/56/481f25466a41d9bb6e0b70b0e059e5611a122b30937081653f69e435625e/zizmor-1.5.0-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2251cc2aa93af78e19d19fc97e58dac9a21f444f441338bcee548298aab64ad0", size = 4815844 },
-    { url = "https://files.pythonhosted.org/packages/b3/86/04496ae14b92505525acd99253788620934548897c55e0812d834724bf5f/zizmor-1.5.0-py3-none-manylinux_2_24_aarch64.whl", hash = "sha256:5f1dd37b95e9712684160c9799dd9584e47fedd99c3228be8b5cb1652e34ca2f", size = 4589817 },
-    { url = "https://files.pythonhosted.org/packages/c5/5b/dd9265a5070edd2ad4bcc72d3e8add62e7b7e5b7f56bb5fe24e553f7535b/zizmor-1.5.0-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:120519b23f12f2732495d2af6df16b0022a60aedafe16eff12b3cc9df94bac39", size = 4576833 },
-    { url = "https://files.pythonhosted.org/packages/9f/fe/ea733866799f143c2868a0e42017a97a5673c6e4af5348515b06c1346c86/zizmor-1.5.0-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:3cfb2b59c6590b445911a0521b7f75879666eee532cd6d944df775413f903187", size = 4514551 },
-    { url = "https://files.pythonhosted.org/packages/34/f4/81f669ff2cdb2a7b8c8176cd740a1e2772c111f04e1221c46123e64dca43/zizmor-1.5.0-py3-none-musllinux_1_2_i686.whl", hash = "sha256:c6fa46b641403f4ab5ca2d1c2d1fa6b33db0b63eef37605180b350e8e0afe04c", size = 4630586 },
-    { url = "https://files.pythonhosted.org/packages/88/ab/c5c55e531b4428bb6b202d6195243f0903f802068384c9449d6991d378b1/zizmor-1.5.0-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:f96bead9a4a435ba1a23d68819039474bd2bed82da01e671e36f2ad424be9f1c", size = 4906119 },
-    { url = "https://files.pythonhosted.org/packages/eb/cb/be8e0b78c3c8aff74532bd9fd1dda03e221b8606d389b9e0b93fc8da5f3e/zizmor-1.5.0-py3-none-win32.whl", hash = "sha256:0c622fdb49ac2a22b8f3243ef7a6ec7612cdd67dbc0ab821714bbe8c84e72ca7", size = 3940268 },
-    { url = "https://files.pythonhosted.org/packages/cc/ad/66d34af4f56134d630bc7ce8c62a4b66057a07d63df08fcaac18f8497922/zizmor-1.5.0-py3-none-win_amd64.whl", hash = "sha256:c9441a2c75715c05fd95c37ffa0fdc0fe03e880edc150963aadb2d59249c873e", size = 4427764 },
+    { url = "https://files.pythonhosted.org/packages/74/0b/94b81c226af45f02936df212cb63bc46d07815b366a80e10ab402b0583dd/zizmor-1.5.1-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:939cd53ac54728a07bbda9ea2db4901caefe8109d27e3022130548142db5b2a2", size = 4680050 },
+    { url = "https://files.pythonhosted.org/packages/53/3d/4b6add58b17471fd0e87509c4a154cf8546f179af0fc0d7c7b270246a0f2/zizmor-1.5.1-py3-none-macosx_11_0_arm64.whl", hash = "sha256:2ae4a4985bdf2070103855cd6ebbf83252f0395d126ff164dc579241f2797129", size = 4426007 },
+    { url = "https://files.pythonhosted.org/packages/b2/3e/4759688497a74f8963d3c95b9f78b9c0711f1b73a4b331c001ad0d4a66f7/zizmor-1.5.1-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:6e3815df2d4e62df7d1d001ddd8359400362803432a6d9082b3a88e9e8120c51", size = 4557425 },
+    { url = "https://files.pythonhosted.org/packages/48/11/4b43594c544b212c6241ba564127d1070a709217fafeba00efd0e15d0e3a/zizmor-1.5.1-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:cec0c96bc13541203aa3bc4d52db275c8d9479bc681efebfe45044ee47da6609", size = 4699878 },
+    { url = "https://files.pythonhosted.org/packages/cf/66/76a96904f230583aa019e7c433b42c7b1d6c299cec85d5b96345be877c8e/zizmor-1.5.1-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9dee012adfca32c8cf3823a964e0bf4197d1c86b36098fccc25582dbb8fa9e12", size = 4998537 },
+    { url = "https://files.pythonhosted.org/packages/93/af/f846b2edf148e16451902c6ec12acc8176c5ba6e7179d0730fa8ac51386d/zizmor-1.5.1-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:be4efbb593f879c4b2b7fa30a0c103f65474b0b3d2edd9ce78fee69068e850c3", size = 6072999 },
+    { url = "https://files.pythonhosted.org/packages/e1/3b/8af99a580abada620d6439a2b4a7080501ff9a8807dec0e41936d60ba2ac/zizmor-1.5.1-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:16ccd5be7823b8dfc77e365f634b32dd59124d5437b9c984cda6d794f20e2718", size = 4820096 },
+    { url = "https://files.pythonhosted.org/packages/ca/6f/bb9db834cedcf847240dfc914b61ed5abec830482aa246672d10f035d2fb/zizmor-1.5.1-py3-none-manylinux_2_24_aarch64.whl", hash = "sha256:9d35dfbc47874bf37c560bb1628f5258333a3a2962e1ca2af4a7283f9368de65", size = 4584608 },
+    { url = "https://files.pythonhosted.org/packages/6e/37/653233b1373715a0dc938f78d7cc19a87f020a4e3af035ecdd5aec6a53e1/zizmor-1.5.1-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:2f1577803bc90845bb6be696dbc39cb8906bf549ddf98ed69bb8033bc30132c1", size = 4577142 },
+    { url = "https://files.pythonhosted.org/packages/89/d3/5b4d5d2d63e4c3494a8f2682a3ed05ae18ab618084a75623a79ff26e70d8/zizmor-1.5.1-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:4aac5d95820a0fed40f1c06b053b21b1ac09d68512af7d4626b515d7cf9ab372", size = 4518790 },
+    { url = "https://files.pythonhosted.org/packages/09/1b/cee0f72993e48cff3734bc62260e8e69d4ef22ca3826a1dcf48b2460c3cc/zizmor-1.5.1-py3-none-musllinux_1_2_i686.whl", hash = "sha256:95507fa0a626ccd63761bb0816b64b6669ffa85b932641074f082358c8c5f487", size = 4631211 },
+    { url = "https://files.pythonhosted.org/packages/90/94/83edfd12a747c9205dfb044c2ac0b328fa4e455343e6d099db6fbaf4d740/zizmor-1.5.1-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:8b37942aa10aa91def98dcae9829624c5a083f5dcb6f10def5a7f4de7652956a", size = 4907104 },
+    { url = "https://files.pythonhosted.org/packages/6a/0a/93199c232cfd21bf64af315d1b30d7e122f8cd623c72e5c9328f79782f4d/zizmor-1.5.1-py3-none-win32.whl", hash = "sha256:d3f6dda5f6bc30476bf18f0ce94f3f2c41f670c82f9260f237d9c9244fb11f61", size = 3943044 },
+    { url = "https://files.pythonhosted.org/packages/f1/c0/9e2839c5cddec48973265509685b97f36bfa354354f9dedad5e6222286e1/zizmor-1.5.1-py3-none-win_amd64.whl", hash = "sha256:8734f8c2f93575d1d0f1a7a6196b90e74bbbb2dfe1e7b7fa690c7dac1be2e959", size = 4430972 },
 ]


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes updates to the development dependencies in the `diagrams` and `scanner` projects. The most important changes are:

Dependency updates:

* [`diagrams/pyproject.toml`](diffhunk://#diff-72922956af93dcd7c4684bd443145f9049c7ae41910c86826ce0a1f46d04d873L11-R11): Updated `ruff` from version 0.9.10 to 0.10.0.
* [`scanner/pyproject.toml`](diffhunk://#diff-a3b82d49d76ebad61ba78436003c53e4907ae972476a9531807ceabd157d7586L15-R17): Updated `ruff` from version 0.9.10 to 0.10.0 and `zizmor` from version 1.5.0 to 1.5.1.