### PR TITLE
Update CodeQL Actions

### DIFF
--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -110,7 +110,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Upload SARIF file
-        uses: github/codeql-action/upload-sarif@v3.28.10
+        uses: github/codeql-action/upload-sarif@v3.28.11
         with:
           sarif_file: results.sarif
           category: zizmor
@@ -147,13 +147,13 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3.28.10
+        uses: github/codeql-action/init@v3.28.11
         with:
           languages: ${{ matrix.language }}
           queries: security-and-quality
           config-file: .github/other-configurations/codeql-config.yml
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v3.28.10
+        uses: github/codeql-action/analyze@v3.28.11
 
   unit-tests:
     name: Run Unit Tests
@@ -209,7 +209,7 @@ jobs:
           RUFF_OUTPUT_FILE: "ruff-results.sarif"
         continue-on-error: true
       - name: Upload Ruff analysis results to GitHub
-        uses: github/codeql-action/upload-sarif@v3.28.10
+        uses: github/codeql-action/upload-sarif@v3.28.11
         with:
           sarif_file: scanner/ruff-results.sarif
           wait-for-processing: true
@@ -252,7 +252,7 @@ jobs:
           RUFF_OUTPUT_FILE: "ruff-results.sarif"
         continue-on-error: true
       - name: Upload Ruff analysis results to GitHub
-        uses: github/codeql-action/upload-sarif@v3.28.10
+        uses: github/codeql-action/upload-sarif@v3.28.11
         with:
           sarif_file: diagrams/ruff-results.sarif
           wait-for-processing: true


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes updates to the `.github/workflows/code-checks.yml` file to upgrade the version of the `github/codeql-action` used in various steps. The most important changes include:

Version updates for `github/codeql-action`:

* Updated `github/codeql-action/upload-sarif` from `v3.28.10` to `v3.28.11` in multiple steps to ensure compatibility and leverage any improvements or fixes. [[1]](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L113-R113) [[2]](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L212-R212) [[3]](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L255-R255)
* Updated `github/codeql-action/init` from `v3.28.10` to `v3.28.11` to initialize CodeQL with the latest version.
* Updated `github/codeql-action/analyze` from `v3.28.10` to `v3.28.11` to perform CodeQL analysis with the latest version.