### PR TITLE
Add UV Dependabot Configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,3 +16,19 @@ updates:
         update-types:
           - "patch"
           - "minor"
+
+  - package-ecosystem: "uv"
+    directories:
+      - "/"
+    schedule:
+      interval: "daily"
+      time: "01:00"
+      timezone: "Europe/London"
+    target-branch: "main"
+    groups:
+      python:
+        patterns:
+          - "*"
+        update-types:
+          - "patch"
+          - "minor"


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes a configuration update to the Dependabot settings in the `.github/dependabot.yml` file. The update introduces a new package ecosystem and scheduling for updates.

Configuration updates:

* Added a new package ecosystem `uv` with daily update scheduling at 01:00 London time, targeting the `main` branch.

Fixes #63 
