### PR TITLE
Add CodeLimit Job

### DIFF
--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -264,3 +264,18 @@ jobs:
         run: just diagrams::ruff-lint-check
         env:
           RUFF_OUTPUT_FORMAT: "github"
+
+  run-code-limit:
+    name: Run CodeLimit
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4.2.2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - name: "Run Code Limit"
+        uses: getcodelimit/codelimit-action@v1


### PR DESCRIPTION
# Pull Request

## Description

This pull request introduces a new job to the GitHub Actions workflow to enforce code limits. The most important change is the addition of the `run-code-limit` job to the `.github/workflows/code-checks.yml` file.

Changes in `.github/workflows/code-checks.yml`:

* Added a new job named `run-code-limit` to enforce code limits using the `getcodelimit/codelimit-action` GitHub Action. This job includes steps for checking out the repository and running the Code Limit action.

Fixes #43 
