### PR TITLE
Analyse Repositories

### DIFF
--- a/scanner/app/__main__.py
+++ b/scanner/app/__main__.py
@@ -2,11 +2,11 @@ from pathlib import Path
 
 from git import rmtree
 from structlog import get_logger, stdlib
-
+from os import walk
 from .configuration import Configuration
 from .custom_logging import set_up_custom_logging
 from .github_interactions import clone_repo, retrieve_repositories
-
+from pygount import SourceAnalysis, ProjectSummary
 logger: stdlib.BoundLogger = get_logger()
 
 
@@ -32,8 +32,24 @@ def run_analyser(configuration: Configuration) -> None:
     repositories = retrieve_repositories(configuration)
     for repository in repositories:
         owner_name, repository_name = repository.owner.login, repository.name
-        clone_repo(owner_name, repository_name)
+        folder_path=clone_repo(owner_name, repository_name)
+        project_summary = ProjectSummary()
+        iterator = Path(folder_path).walk()
+        for _root, _dirs, files in iterator:
+            for file in files:
+                file_path = f"{_root.__str__()}/{file}"
+                logger.debug("Analysing file", file=file_path)
+                file_analysis = SourceAnalysis.from_file(file_path, repository_name)
+                logger.debug("File analysis", file_analysis=file_analysis)
+                if file_analysis.language not in ["__unknown__", "__empty__", "__error__"]:
+                    project_summary.add(file_analysis)
+        logger.info("Project summary", project_summary=project_summary)
 
+        # for source_path in walk(folder_path):
+        #     source_analysis = SourceAnalysis.from_file(source_path, "pygount")
+        #     project_summary.add(source_analysis)
+        # for language_summary in project_summary.language_to_language_summary_map.values():
+        #     logger.info(language_summary)
 
 def clean_up() -> None:
     """Clean up the cloned repositories."""

--- a/scanner/app/__main__.py
+++ b/scanner/app/__main__.py
@@ -1,12 +1,13 @@
 from pathlib import Path
 
 from git import rmtree
+from pygount import ProjectSummary, SourceAnalysis
 from structlog import get_logger, stdlib
-from os import walk
+
 from .configuration import Configuration
 from .custom_logging import set_up_custom_logging
 from .github_interactions import clone_repo, retrieve_repositories
-from pygount import SourceAnalysis, ProjectSummary
+
 logger: stdlib.BoundLogger = get_logger()
 
 
@@ -32,7 +33,7 @@ def run_analyser(configuration: Configuration) -> None:
     repositories = retrieve_repositories(configuration)
     for repository in repositories:
         owner_name, repository_name = repository.owner.login, repository.name
-        folder_path=clone_repo(owner_name, repository_name)
+        folder_path = clone_repo(owner_name, repository_name)
         project_summary = ProjectSummary()
         iterator = Path(folder_path).walk()
         for _root, _dirs, files in iterator:
@@ -41,15 +42,14 @@ def run_analyser(configuration: Configuration) -> None:
                 logger.debug("Analysing file", file=file_path)
                 file_analysis = SourceAnalysis.from_file(file_path, repository_name)
                 logger.debug("File analysis", file_analysis=file_analysis)
-                if file_analysis.language not in ["__unknown__", "__empty__", "__error__"]:
+                if file_analysis.language not in [
+                    "__unknown__",
+                    "__empty__",
+                    "__error__",
+                ]:
                     project_summary.add(file_analysis)
         logger.info("Project summary", project_summary=project_summary)
 
-        # for source_path in walk(folder_path):
-        #     source_analysis = SourceAnalysis.from_file(source_path, "pygount")
-        #     project_summary.add(source_analysis)
-        # for language_summary in project_summary.language_to_language_summary_map.values():
-        #     logger.info(language_summary)
 
 def clean_up() -> None:
     """Clean up the cloned repositories."""

--- a/scanner/pyproject.toml
+++ b/scanner/pyproject.toml
@@ -6,13 +6,14 @@ dependencies = [
   "gitpython==3.1.44",
   "pygithub==2.6.0",
   "structlog==25.1.0",
+  "pygount==1.8.0",
 ]
 
 [project.optional-dependencies]
 dev = [
   "pytest==8.3.5",
   "pytest-cov==6.0.0",
-  "ruff==0.10.0",
+  "ruff==0.11.0",
   "vulture==2.14",
   "zizmor==1.5.1",
 ]
@@ -20,6 +21,9 @@ dev = [
 [tool.uv]
 required-version = "0.6.6"
 package = false
+
+[tool.setuptools]
+py-modules = ["app", "cloned_repositories"]
 
 [tool.ruff]
 target-version = "py313"

--- a/scanner/pyproject.toml
+++ b/scanner/pyproject.toml
@@ -6,7 +6,7 @@ dependencies = [
   "gitpython==3.1.44",
   "pygithub==2.6.0",
   "structlog==25.1.0",
-  "pygount==1.8.0",
+  "pygount==2.0.0",
 ]
 
 [project.optional-dependencies]

--- a/scanner/uv.lock
+++ b/scanner/uv.lock
@@ -267,7 +267,7 @@ wheels = [
 
 [[package]]
 name = "pygount"
-version = "1.8.0"
+version = "2.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "chardet" },
@@ -275,9 +275,9 @@ dependencies = [
     { name = "pygments" },
     { name = "rich" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/36/1a/3d888ff0e1bb40602ffe54727311f985e7f8ece6f1b8a3d7564fe98f6852/pygount-1.8.0.tar.gz", hash = "sha256:a1c530a8ff473c99dc7cd24b034f382d60f51efcac3a1d2181642124dbda2173", size = 26848 }
+sdist = { url = "https://files.pythonhosted.org/packages/1d/e3/1d6708e6af3e1fdbe404ef3f8033cc786749371f432ec984808cde3e7ad5/pygount-2.0.0.tar.gz", hash = "sha256:7eb27c5095e3bb677e23d23e22707486b470d44a56fa3b41258f58d08968cc0d", size = 28491 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/31/aa/5f21aa9c97d141ff893a55731b6791363332a331b3167f39604ace7194b0/pygount-1.8.0-py3-none-any.whl", hash = "sha256:bb4e27ae3709674a91e349f503240ffeaef7efa59d1e026c7e4b2278dd3deb7f", size = 28792 },
+    { url = "https://files.pythonhosted.org/packages/6d/fa/7ad968b663abe21c750c15f3869de3069875d1c03faa96ce7681a7d8dfbb/pygount-2.0.0-py3-none-any.whl", hash = "sha256:4c5d83d8069ea13a5740d3155d314508af1b6c37391777c9fc656dac3f904d57", size = 29830 },
 ]
 
 [[package]]
@@ -418,7 +418,7 @@ dev = [
 requires-dist = [
     { name = "gitpython", specifier = "==3.1.44" },
     { name = "pygithub", specifier = "==2.6.0" },
-    { name = "pygount", specifier = "==1.8.0" },
+    { name = "pygount", specifier = "==2.0.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = "==8.3.5" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = "==6.0.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = "==0.11.0" },

--- a/scanner/uv.lock
+++ b/scanner/uv.lock
@@ -34,6 +34,15 @@ wheels = [
 ]
 
 [[package]]
+name = "chardet"
+version = "5.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f3/0d/f7b6ab21ec75897ed80c17d79b15951a719226b9fababf1e40ea74d69079/chardet-5.2.0.tar.gz", hash = "sha256:1b3b6ff479a8c414bc3fa2c0852995695c4a026dcd6d0633b2dd092ca39c1cf7", size = 2069618 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/38/6f/f5fbc992a329ee4e0f288c1fe0e2ad9485ed064cac731ed2fe47dcc38cbf/chardet-5.2.0-py3-none-any.whl", hash = "sha256:e1cf59446890a00105fe7b7912492ea04b6e6f06d4b742b2c788469e34c82970", size = 199385 },
+]
+
+[[package]]
 name = "charset-normalizer"
 version = "3.4.1"
 source = { registry = "https://pypi.org/simple" }
@@ -183,6 +192,27 @@ wheels = [
 ]
 
 [[package]]
+name = "markdown-it-py"
+version = "3.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mdurl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/38/71/3b932df36c1a044d397a1f92d1cf91ee0a503d91e470cbd670aa66b07ed0/markdown-it-py-3.0.0.tar.gz", hash = "sha256:e3f60a94fa066dc52ec76661e37c851cb232d92f9886b15cb560aaada2df8feb", size = 74596 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/42/d7/1ec15b46af6af88f19b8e5ffea08fa375d433c998b8a7639e76935c14f1f/markdown_it_py-3.0.0-py3-none-any.whl", hash = "sha256:355216845c60bd96232cd8d8c40e8f9765cc86f46880e43a8fd22dc1a1a8cab1", size = 87528 },
+]
+
+[[package]]
+name = "mdurl"
+version = "0.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979 },
+]
+
+[[package]]
 name = "packaging"
 version = "24.2"
 source = { registry = "https://pypi.org/simple" }
@@ -224,6 +254,30 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/60/7a/78a40edc07426052eb909f556deb8ae3158c234df49553bd4690bc6c4ba7/pygithub-2.6.0.tar.gz", hash = "sha256:04784fd6f4acfcaf91df5d3f08ef14153709395a34e706850f92337d9914548f", size = 3658095 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f3/9e/ba08aa9e1632f8752648126505598b95429fcb7bb884c1eb9de5b2370d8f/PyGithub-2.6.0-py3-none-any.whl", hash = "sha256:22635b245b885413c607bb86393603cadcfdcb67a9b81ce9a64634e64f308084", size = 409218 },
+]
+
+[[package]]
+name = "pygments"
+version = "2.19.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7c/2d/c3338d48ea6cc0feb8446d8e6937e1408088a72a39937982cc6111d17f84/pygments-2.19.1.tar.gz", hash = "sha256:61c16d2a8576dc0649d9f39e089b5f02bcd27fba10d8fb4dcc28173f7a45151f", size = 4968581 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8a/0b/9fcc47d19c48b59121088dd6da2488a49d5f72dacf8262e2790a1d2c7d15/pygments-2.19.1-py3-none-any.whl", hash = "sha256:9ea1544ad55cecf4b8242fab6dd35a93bbce657034b0611ee383099054ab6d8c", size = 1225293 },
+]
+
+[[package]]
+name = "pygount"
+version = "1.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "chardet" },
+    { name = "gitpython" },
+    { name = "pygments" },
+    { name = "rich" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/36/1a/3d888ff0e1bb40602ffe54727311f985e7f8ece6f1b8a3d7564fe98f6852/pygount-1.8.0.tar.gz", hash = "sha256:a1c530a8ff473c99dc7cd24b034f382d60f51efcac3a1d2181642124dbda2173", size = 26848 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/31/aa/5f21aa9c97d141ff893a55731b6791363332a331b3167f39604ace7194b0/pygount-1.8.0-py3-none-any.whl", hash = "sha256:bb4e27ae3709674a91e349f503240ffeaef7efa59d1e026c7e4b2278dd3deb7f", size = 28792 },
 ]
 
 [[package]]
@@ -304,28 +358,41 @@ wheels = [
 ]
 
 [[package]]
-name = "ruff"
-version = "0.10.0"
+name = "rich"
+version = "13.9.4"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/4c/ec/9c59d2956566517c98ac8267554f4eaceafb2a19710a429368518b7fab43/ruff-0.10.0.tar.gz", hash = "sha256:fa1554e18deaf8aa097dbcfeafaf38b17a2a1e98fdc18f50e62e8a836abee392", size = 3789921 }
+dependencies = [
+    { name = "markdown-it-py" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ab/3a/0316b28d0761c6734d6bc14e770d85506c986c85ffb239e688eeaab2c2bc/rich-13.9.4.tar.gz", hash = "sha256:439594978a49a09530cff7ebc4b5c7103ef57baf48d5ea3184f21d9a2befa098", size = 223149 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/bf/3f/742afe91b43def2a75990b293c676355576c0ff9cdbcf4249f78fa592544/ruff-0.10.0-py3-none-linux_armv6l.whl", hash = "sha256:46a2aa0eaae5048e5f804f0be9489d8a661633e23277b7293089e70d5c1a35c4", size = 10078369 },
-    { url = "https://files.pythonhosted.org/packages/8d/a0/8696fb4862e82f7b40bbbc2917137594b22826cc62d77278a91391507514/ruff-0.10.0-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:775a6bc61af9dd0a2e1763406522a137e62aabb743d8b43ed95f019cdd1526c7", size = 10876912 },
-    { url = "https://files.pythonhosted.org/packages/40/aa/0d48b7b7d7a1f168bb8fd893ed559d633c7d68c4a8ef9b996f0c2bd07aca/ruff-0.10.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:8b03e6fcd39d20f0004f9956f0ed5eadc404d3a299f9d9286323884e3b663730", size = 10229962 },
-    { url = "https://files.pythonhosted.org/packages/21/de/861ced2f75b045d8cfc038d68961d8ac117344df1f43a11abdd05bf7991b/ruff-0.10.0-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:621101d1af80248827f2409a78c8177c8319986a57b4663613b9c72f8617bfcd", size = 10404627 },
-    { url = "https://files.pythonhosted.org/packages/21/69/666e0b840191c3ce433962c0d05fc0f6800afe259ea5d230cc731655d8e2/ruff-0.10.0-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:e2dfe85cb6bfbd4259801e7d4982f2a72bdbd5749dc73a09d68a6dbf77f2209a", size = 9939383 },
-    { url = "https://files.pythonhosted.org/packages/76/bf/34a2adc58092c99cdfa9f1303acd82d840d56412022e477e2ab20c261d2d/ruff-0.10.0-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:43ac3879a20c22fdc57e559f0bb27f0c71828656841d0b42d3505b1e5b3a83c8", size = 11492269 },
-    { url = "https://files.pythonhosted.org/packages/31/3d/f7ccfcf69f15948623b190feea9d411d5029ae39725fcc078f8d43bd07a6/ruff-0.10.0-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:ef5e3aac421bbc62f8a7aab21edd49a359ed42205f7a5091a74386bca1efa293", size = 12186939 },
-    { url = "https://files.pythonhosted.org/packages/6e/3e/c557c0abfdea85c7d238a3cb238c73e7b6d17c30a584234c4fd8fe2cafb6/ruff-0.10.0-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9f4f62d7fac8b748fce67ad308116b4d4cc1a9f964b4804fc5408fbd06e13ba9", size = 11655896 },
-    { url = "https://files.pythonhosted.org/packages/3b/8e/3bfa110f37e5192eb3943f14943d05fbb9a76fea380aa87655e6f6276a54/ruff-0.10.0-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:02f9f6205c5b0d626f98da01a0e75b724a64c21c554bba24b12522c9e9ba6a04", size = 13885502 },
-    { url = "https://files.pythonhosted.org/packages/51/4a/22cdab59b5563dd7f4c504d0f1e6bb25fc800a5a057395bc24f8ff3a85b2/ruff-0.10.0-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:46a97f3d55f68464c48d1e929a8582c7e5bb80ac73336bbc7b0da894d8e6cd9e", size = 11344767 },
-    { url = "https://files.pythonhosted.org/packages/3d/0f/8f85de2ac565f82f47c6d8fb7ae04383e6300560f2d1b91c1268ff91e507/ruff-0.10.0-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:a0b811197d0dc96c13d610f8cfdc56030b405bcff5c2f10eab187b329da0ca4a", size = 10300331 },
-    { url = "https://files.pythonhosted.org/packages/90/4a/b337df327832cb30bd8607e8d1fdf1b6b5ca228307d5008dd49028fb66ae/ruff-0.10.0-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:a13a3fda0870c1c964b47ff5d73805ae80d2a9de93ee2d185d453b8fddf85a84", size = 9926551 },
-    { url = "https://files.pythonhosted.org/packages/d7/e9/141233730b85675ac806c4b62f70516bd9c0aae8a55823f3a6589ed411be/ruff-0.10.0-py3-none-musllinux_1_2_i686.whl", hash = "sha256:6ceb8d9f062e90ddcbad929f6136edf764bbf6411420a07e8357602ea28cd99f", size = 10925061 },
-    { url = "https://files.pythonhosted.org/packages/24/09/02987935b55c2d353a226ac1b4f9718830e2e195834929f46c07eeede746/ruff-0.10.0-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:c41d07d573617ed2f287ea892af2446fd8a8d877481e8e1ba6928e020665d240", size = 11394949 },
-    { url = "https://files.pythonhosted.org/packages/d6/ec/054f9879fb6f4122d43ffe5c9f88c8c323a9cd14220d5c813aea5805e02c/ruff-0.10.0-py3-none-win32.whl", hash = "sha256:76e2de0cbdd587e373cd3b4050d2c45babdd7014c1888a6f121c29525c748a15", size = 10272077 },
-    { url = "https://files.pythonhosted.org/packages/6e/49/915d8682f24645b904fe6a1aac36101464fc814923fdf293c1388dc5533c/ruff-0.10.0-py3-none-win_amd64.whl", hash = "sha256:f943acdecdcc6786a8d1dad455dd9f94e6d57ccc115be4993f9b52ef8316027a", size = 11393300 },
-    { url = "https://files.pythonhosted.org/packages/82/ed/5c59941634c9026ceeccc7c119f23f4356f09aafd28c15c1bc734ac66b01/ruff-0.10.0-py3-none-win_arm64.whl", hash = "sha256:935a943bdbd9ff0685acd80d484ea91088e27617537b5f7ef8907187d19d28d0", size = 10510133 },
+    { url = "https://files.pythonhosted.org/packages/19/71/39c7c0d87f8d4e6c020a393182060eaefeeae6c01dab6a84ec346f2567df/rich-13.9.4-py3-none-any.whl", hash = "sha256:6049d5e6ec054bf2779ab3358186963bac2ea89175919d699e378b99738c2a90", size = 242424 },
+]
+
+[[package]]
+name = "ruff"
+version = "0.11.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/77/2b/7ca27e854d92df5e681e6527dc0f9254c9dc06c8408317893cf96c851cdd/ruff-0.11.0.tar.gz", hash = "sha256:e55c620690a4a7ee6f1cccb256ec2157dc597d109400ae75bbf944fc9d6462e2", size = 3799407 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/48/40/3d0340a9e5edc77d37852c0cd98c5985a5a8081fc3befaeb2ae90aaafd2b/ruff-0.11.0-py3-none-linux_armv6l.whl", hash = "sha256:dc67e32bc3b29557513eb7eeabb23efdb25753684b913bebb8a0c62495095acb", size = 10098158 },
+    { url = "https://files.pythonhosted.org/packages/ec/a9/d8f5abb3b87b973b007649ac7bf63665a05b2ae2b2af39217b09f52abbbf/ruff-0.11.0-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:38c23fd9bdec4eb437b4c1e3595905a0a8edfccd63a790f818b28c78fe345639", size = 10879071 },
+    { url = "https://files.pythonhosted.org/packages/ab/62/aaa198614c6211677913ec480415c5e6509586d7b796356cec73a2f8a3e6/ruff-0.11.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:7c8661b0be91a38bd56db593e9331beaf9064a79028adee2d5f392674bbc5e88", size = 10247944 },
+    { url = "https://files.pythonhosted.org/packages/9f/52/59e0a9f2cf1ce5e6cbe336b6dd0144725c8ea3b97cac60688f4e7880bf13/ruff-0.11.0-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b6c0e8d3d2db7e9f6efd884f44b8dc542d5b6b590fc4bb334fdbc624d93a29a2", size = 10421725 },
+    { url = "https://files.pythonhosted.org/packages/a6/c3/dcd71acc6dff72ce66d13f4be5bca1dbed4db678dff2f0f6f307b04e5c02/ruff-0.11.0-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:3c3156d3f4b42e57247275a0a7e15a851c165a4fc89c5e8fa30ea6da4f7407b8", size = 9954435 },
+    { url = "https://files.pythonhosted.org/packages/a6/9a/342d336c7c52dbd136dee97d4c7797e66c3f92df804f8f3b30da59b92e9c/ruff-0.11.0-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:490b1e147c1260545f6d041c4092483e3f6d8eba81dc2875eaebcf9140b53905", size = 11492664 },
+    { url = "https://files.pythonhosted.org/packages/84/35/6e7defd2d7ca95cc385ac1bd9f7f2e4a61b9cc35d60a263aebc8e590c462/ruff-0.11.0-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:1bc09a7419e09662983b1312f6fa5dab829d6ab5d11f18c3760be7ca521c9329", size = 12207856 },
+    { url = "https://files.pythonhosted.org/packages/22/78/da669c8731bacf40001c880ada6d31bcfb81f89cc996230c3b80d319993e/ruff-0.11.0-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:bcfa478daf61ac8002214eb2ca5f3e9365048506a9d52b11bea3ecea822bb844", size = 11645156 },
+    { url = "https://files.pythonhosted.org/packages/ee/47/e27d17d83530a208f4a9ab2e94f758574a04c51e492aa58f91a3ed7cbbcb/ruff-0.11.0-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:6fbb2aed66fe742a6a3a0075ed467a459b7cedc5ae01008340075909d819df1e", size = 13884167 },
+    { url = "https://files.pythonhosted.org/packages/9f/5e/42ffbb0a5d4b07bbc642b7d58357b4e19a0f4774275ca6ca7d1f7b5452cd/ruff-0.11.0-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:92c0c1ff014351c0b0cdfdb1e35fa83b780f1e065667167bb9502d47ca41e6db", size = 11348311 },
+    { url = "https://files.pythonhosted.org/packages/c8/51/dc3ce0c5ce1a586727a3444a32f98b83ba99599bb1ebca29d9302886e87f/ruff-0.11.0-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:e4fd5ff5de5f83e0458a138e8a869c7c5e907541aec32b707f57cf9a5e124445", size = 10305039 },
+    { url = "https://files.pythonhosted.org/packages/60/e0/475f0c2f26280f46f2d6d1df1ba96b3399e0234cf368cc4c88e6ad10dcd9/ruff-0.11.0-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:96bc89a5c5fd21a04939773f9e0e276308be0935de06845110f43fd5c2e4ead7", size = 9937939 },
+    { url = "https://files.pythonhosted.org/packages/e2/d3/3e61b7fd3e9cdd1e5b8c7ac188bec12975c824e51c5cd3d64caf81b0331e/ruff-0.11.0-py3-none-musllinux_1_2_i686.whl", hash = "sha256:a9352b9d767889ec5df1483f94870564e8102d4d7e99da52ebf564b882cdc2c7", size = 10923259 },
+    { url = "https://files.pythonhosted.org/packages/30/32/cd74149ebb40b62ddd14bd2d1842149aeb7f74191fb0f49bd45c76909ff2/ruff-0.11.0-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:049a191969a10897fe052ef9cc7491b3ef6de79acd7790af7d7897b7a9bfbcb6", size = 11406212 },
+    { url = "https://files.pythonhosted.org/packages/00/ef/033022a6b104be32e899b00de704d7c6d1723a54d4c9e09d147368f14b62/ruff-0.11.0-py3-none-win32.whl", hash = "sha256:3191e9116b6b5bbe187447656f0c8526f0d36b6fd89ad78ccaad6bdc2fad7df2", size = 10310905 },
+    { url = "https://files.pythonhosted.org/packages/ed/8a/163f2e78c37757d035bd56cd60c8d96312904ca4a6deeab8442d7b3cbf89/ruff-0.11.0-py3-none-win_amd64.whl", hash = "sha256:c58bfa00e740ca0a6c43d41fb004cd22d165302f360aaa56f7126d544db31a21", size = 11411730 },
+    { url = "https://files.pythonhosted.org/packages/4e/f7/096f6efabe69b49d7ca61052fc70289c05d8d35735c137ef5ba5ef423662/ruff-0.11.0-py3-none-win_arm64.whl", hash = "sha256:868364fc23f5aa122b00c6f794211e85f7e78f5dffdf7c590ab90b8c4e69b657", size = 10538956 },
 ]
 
 [[package]]
@@ -334,6 +401,7 @@ source = { virtual = "." }
 dependencies = [
     { name = "gitpython" },
     { name = "pygithub" },
+    { name = "pygount" },
     { name = "structlog" },
 ]
 
@@ -350,9 +418,10 @@ dev = [
 requires-dist = [
     { name = "gitpython", specifier = "==3.1.44" },
     { name = "pygithub", specifier = "==2.6.0" },
+    { name = "pygount", specifier = "==1.8.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = "==8.3.5" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = "==6.0.0" },
-    { name = "ruff", marker = "extra == 'dev'", specifier = "==0.10.0" },
+    { name = "ruff", marker = "extra == 'dev'", specifier = "==0.11.0" },
     { name = "structlog", specifier = "==25.1.0" },
     { name = "vulture", marker = "extra == 'dev'", specifier = "==2.14" },
     { name = "zizmor", marker = "extra == 'dev'", specifier = "==1.5.1" },


### PR DESCRIPTION
# Pull Request

## Description

This pull request introduces the use of the `pygount` library to analyze source code in cloned repositories and updates the project dependencies accordingly. Below are the most important changes:

### Integration of `pygount` for Source Code Analysis:

* [`scanner/app/__main__.py`](diffhunk://#diff-e370c8f7bf64354b82fe45c59db166c3b80722cbe29d17342bad06377b071639R4): Added imports for `ProjectSummary` and `SourceAnalysis` from `pygount`. Enhanced the `run_analyser` function to analyze files in cloned repositories using `pygount`, logging the analysis results and creating a project summary. [[1]](diffhunk://#diff-e370c8f7bf64354b82fe45c59db166c3b80722cbe29d17342bad06377b071639R4) [[2]](diffhunk://#diff-e370c8f7bf64354b82fe45c59db166c3b80722cbe29d17342bad06377b071639L35-R51)

### Dependency Updates:

* [`scanner/pyproject.toml`](diffhunk://#diff-a3b82d49d76ebad61ba78436003c53e4907ae972476a9531807ceabd157d7586R9-R16): Added `pygount==2.0.0` to the list of dependencies. Updated the version of `ruff` in the optional development dependencies. [[1]](diffhunk://#diff-a3b82d49d76ebad61ba78436003c53e4907ae972476a9531807ceabd157d7586R9-R16) [[2]](diffhunk://#diff-a3b82d49d76ebad61ba78436003c53e4907ae972476a9531807ceabd157d7586R25-R27)

Fixes #6 
