### PR TITLE
UV Update

### DIFF
--- a/diagrams/pyproject.toml
+++ b/diagrams/pyproject.toml
@@ -2,17 +2,13 @@
 name = "generate-diagrams"
 dynamic = ["version"]
 requires-python = ">=3.13"
-dependencies = [
-  "diagrams==0.24.4"
-]
+dependencies = ["diagrams==0.24.4"]
 
 [project.optional-dependencies]
-dev = [
-  "ruff==0.11.0"
-]
+dev = ["ruff==0.11.0"]
 
 [tool.uv]
-required-version = "0.6.6"
+required-version = "0.6.8"
 package = false
 
 [tool.ruff]
@@ -60,7 +56,3 @@ dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
 
 [tool.ruff.lint.pydocstyle]
 convention = "google"
-
-[tool.ruff.lint.isort]
-known-first-party = ["scanner"]
-

--- a/scanner/pyproject.toml
+++ b/scanner/pyproject.toml
@@ -19,7 +19,7 @@ dev = [
 ]
 
 [tool.uv]
-required-version = "0.6.6"
+required-version = "0.6.8"
 package = false
 
 [tool.setuptools]
@@ -80,4 +80,3 @@ norecursedirs = "cloned_repositories"
 [tool.vulture]
 exclude = [".venv"]
 ignore_names = ["summary"]
-

--- a/tests/pyproject.toml
+++ b/tests/pyproject.toml
@@ -2,12 +2,8 @@
 name = "scanner"
 dynamic = ["version"]
 requires-python = ">=3.13"
-dependencies = [
-  "check-jsonschema==0.31.0"
-]
+dependencies = ["check-jsonschema==0.31.0"]
 
 [tool.uv]
-required-version = "0.6.6"
+required-version = "0.6.8"
 package = false
-
-


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes several updates to the `pyproject.toml` files across multiple directories. The changes primarily focus on formatting adjustments and updating dependency versions.

Dependency updates and formatting changes:

* [`diagrams/pyproject.toml`](diffhunk://#diff-72922956af93dcd7c4684bd443145f9049c7ae41910c86826ce0a1f46d04d873L5-R11): Updated `required-version` for `uv` from `0.6.6` to `0.6.8`. Formatted `dependencies` and `dev` lists to be inline.
* [`scanner/pyproject.toml`](diffhunk://#diff-a3b82d49d76ebad61ba78436003c53e4907ae972476a9531807ceabd157d7586L22-R22): Updated `required-version` for `uv` from `0.6.6` to `0.6.8`. Removed an unnecessary newline in the `vulture` section. [[1]](diffhunk://#diff-a3b82d49d76ebad61ba78436003c53e4907ae972476a9531807ceabd157d7586L22-R22) [[2]](diffhunk://#diff-a3b82d49d76ebad61ba78436003c53e4907ae972476a9531807ceabd157d7586L83)
* [`tests/pyproject.toml`](diffhunk://#diff-03049af3cb225ee5c5f22bc10731df89191cc762ad9ca9aa4cb7d3a87786ac8dL5-L13): Updated `required-version` for `uv` from `0.6.6` to `0.6.8`. Formatted `dependencies` list to be inline.

Other changes:

* [`diagrams/pyproject.toml`](diffhunk://#diff-72922956af93dcd7c4684bd443145f9049c7ae41910c86826ce0a1f46d04d873L63-L66): Removed `tool.ruff.lint.isort` section.
