### PR TITLE
Add Tests Formatting and Linting Workflow

### DIFF
--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -243,6 +243,42 @@ jobs:
       - name: UV Lock Check
         run: just diagrams::uv-lock-check
 
+  run-tests-python-code-checks:
+    name: Run Tests Python Code Checks
+    runs-on: ubuntu-latest
+    permissions:
+      statuses: write
+      security-events: write
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4.2.2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Setup Tests Dependencies
+        uses: ./.github/actions/setup-tests-dependencies
+      - name: Generate Ruff Sarif
+        run: just tests::ruff-lint-check
+        env:
+          RUFF_OUTPUT_FORMAT: "sarif"
+          RUFF_OUTPUT_FILE: "ruff-results.sarif"
+        continue-on-error: true
+      - name: Upload Ruff analysis results to GitHub
+        uses: github/codeql-action/upload-sarif@v3.28.11
+        with:
+          sarif_file: tests/ruff-results.sarif
+          wait-for-processing: true
+      - name: Check Python Code Format (Ruff)
+        run: just tests::ruff-format-check
+        env:
+          RUFF_OUTPUT_FORMAT: "github"
+      - name: Check Python Code Linting (Ruff)
+        run: just tests::ruff-lint-check
+        env:
+          RUFF_OUTPUT_FORMAT: "github"
+      - name: UV Lock Check
+        run: just tests::uv-lock-check
+
   run-code-limit:
     name: Run CodeLimit
     runs-on: ubuntu-latest

--- a/diagrams/pyproject.toml
+++ b/diagrams/pyproject.toml
@@ -8,7 +8,7 @@ dependencies = ["diagrams==0.24.4"]
 dev = ["ruff==0.11.0"]
 
 [tool.uv]
-required-version = "0.6.8"
+required-version = "0.6.10"
 package = false
 
 [tool.ruff]

--- a/scanner/pyproject.toml
+++ b/scanner/pyproject.toml
@@ -19,7 +19,7 @@ dev = [
 ]
 
 [tool.uv]
-required-version = "0.6.8"
+required-version = "0.6.10"
 package = false
 
 [tool.setuptools]

--- a/tests/pyproject.toml
+++ b/tests/pyproject.toml
@@ -5,7 +5,7 @@ requires-python = ">=3.13"
 dependencies = ["check-jsonschema==0.31.0", "pytest==8.3.5", "ruff==0.11.0"]
 
 [tool.uv]
-required-version = "0.6.8"
+required-version = "0.6.10"
 package = false
 
 [tool.ruff]

--- a/tests/pyproject.toml
+++ b/tests/pyproject.toml
@@ -2,8 +2,54 @@
 name = "scanner"
 dynamic = ["version"]
 requires-python = ">=3.13"
-dependencies = ["check-jsonschema==0.31.0"]
+dependencies = ["check-jsonschema==0.31.0", "pytest==8.3.5", "ruff==0.11.0"]
 
 [tool.uv]
 required-version = "0.6.8"
 package = false
+
+[tool.ruff]
+target-version = "py313"
+
+[tool.ruff.lint]
+extend-select = ["E501"]
+select = ["ALL"]
+
+ignore = [
+  "COM812",  # Ignore due to conflict with Ruff formatter
+  "ISC001",  # Ignore due to conflict with Ruff formatter
+  "PLR2004", # Ignore magic value
+  "D104",    # Ignore missing docstring in public package
+  "D100",    # Ignore missing docstring in public module
+  "N999",    # Ignore invalid module name
+  "SIM112",  # Ignore Lowercase environment variables (used for GitHub actions)
+]
+
+fixable = ["ALL"]
+unfixable = []
+
+exclude = [
+  ".bzr",
+  ".direnv",
+  ".eggs",
+  ".git",
+  ".hg",
+  ".mypy_cache",
+  ".nox",
+  ".pants.d",
+  ".pytype",
+  ".ruff_cache",
+  ".svn",
+  ".tox",
+  ".venv",
+  "__pypackages__",
+  "_build",
+]
+
+dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
+
+[tool.ruff.lint.per-file-ignores]
+"**test_*.py" = ["S101", "D102", "D103", "SLF001", "PT019", "PLR0913"]
+
+[tool.ruff.lint.pydocstyle]
+convention = "google"

--- a/tests/tests.just
+++ b/tests/tests.just
@@ -23,19 +23,19 @@ ruff-checks:
 
 # Check for Ruff issues
 ruff-lint-check:
-    uv run ruff check app
+    uv run ruff check .
 
 # Fix Ruff lint issues
 ruff-lint-fix:
-    uv run ruff check app --fix
+    uv run ruff check . --fix
 
 # Check for Ruff format issues
 ruff-format-check:
-    uv run ruff format --check app
+    uv run ruff format --check .
 
 # Fix Ruff format issues
 ruff-format-fix:
-    uv run ruff format app
+    uv run ruff format .
 
 # ------------------------------------------------------------------------------
 # UV

--- a/tests/tests.just
+++ b/tests/tests.just
@@ -7,6 +7,37 @@ validate-schema:
     uv run check-jsonschema --schemafile schema_validation/output_schema.json schema_validation/output.json
 
 # ------------------------------------------------------------------------------
+# Ruff - Python Linting and Formatting
+# Set up ruff red-knot when it's ready
+# ------------------------------------------------------------------------------
+
+# Fix all Ruff issues
+ruff-fix:
+    just scanner::ruff-format-fix
+    just scanner::ruff-lint-fix
+
+# Check for all Ruff issues
+ruff-checks:
+    just scanner::ruff-format-check
+    just scanner::ruff-lint-check
+
+# Check for Ruff issues
+ruff-lint-check:
+    uv run ruff check app
+
+# Fix Ruff lint issues
+ruff-lint-fix:
+    uv run ruff check app --fix
+
+# Check for Ruff format issues
+ruff-format-check:
+    uv run ruff format --check app
+
+# Fix Ruff format issues
+ruff-format-fix:
+    uv run ruff format app
+
+# ------------------------------------------------------------------------------
 # UV
 # ------------------------------------------------------------------------------
 

--- a/tests/uv.lock
+++ b/tests/uv.lock
@@ -89,6 +89,15 @@ wheels = [
 ]
 
 [[package]]
+name = "iniconfig"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/4b/cbd8e699e64a6f16ca3a8220661b5f83792b3017d0f79807cb8708d33913/iniconfig-2.0.0.tar.gz", hash = "sha256:2d91e135bf72d31a410b17c16da610a82cb55f6b0477d1a902134b24a455b8b3", size = 4646 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ef/a6/62565a6e1cf69e10f5727360368e451d4b7f58beeac6173dc9db836a5b46/iniconfig-2.0.0-py3-none-any.whl", hash = "sha256:b6a85871a79d2e3b22d2d1b94ac2824226a63c6b741c88f7ae975f18b6778374", size = 5892 },
+]
+
+[[package]]
 name = "jsonschema"
 version = "4.23.0"
 source = { registry = "https://pypi.org/simple" }
@@ -113,6 +122,39 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/10/db/58f950c996c793472e336ff3655b13fbcf1e3b359dcf52dcf3ed3b52c352/jsonschema_specifications-2024.10.1.tar.gz", hash = "sha256:0f38b83639958ce1152d02a7f062902c41c8fd20d558b0c34344292d417ae272", size = 15561 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d1/0f/8910b19ac0670a0f80ce1008e5e751c4a57e14d2c4c13a482aa6079fa9d6/jsonschema_specifications-2024.10.1-py3-none-any.whl", hash = "sha256:a09a0680616357d9a0ecf05c12ad234479f549239d0f5b55f3deea67475da9bf", size = 18459 },
+]
+
+[[package]]
+name = "packaging"
+version = "24.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d0/63/68dbb6eb2de9cb10ee4c9c14a0148804425e13c4fb20d61cce69f53106da/packaging-24.2.tar.gz", hash = "sha256:c228a6dc5e932d346bc5739379109d49e8853dd8223571c7c5b55260edc0b97f", size = 163950 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/ef/eb23f262cca3c0c4eb7ab1933c3b1f03d021f2c48f54763065b6f0e321be/packaging-24.2-py3-none-any.whl", hash = "sha256:09abb1bccd265c01f4a3aa3f7a7db064b36514d2cba19a2f694fe6150451a759", size = 65451 },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.5.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/96/2d/02d4312c973c6050a18b314a5ad0b3210edb65a906f868e31c111dede4a6/pluggy-1.5.0.tar.gz", hash = "sha256:2cffa88e94fdc978c4c574f15f9e59b7f4201d439195c3715ca9e2486f1d0cf1", size = 67955 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/5f/e351af9a41f866ac3f1fac4ca0613908d9a41741cfcf2228f4ad853b697d/pluggy-1.5.0-py3-none-any.whl", hash = "sha256:44e1ad92c8ca002de6377e165f3e0f1be63266ab4d554740532335b9d75ea669", size = 20556 },
+]
+
+[[package]]
+name = "pytest"
+version = "8.3.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ae/3c/c9d525a414d506893f0cd8a8d0de7706446213181570cdbd766691164e40/pytest-8.3.5.tar.gz", hash = "sha256:f4efe70cc14e511565ac476b57c279e12a855b11f48f212af1080ef2263d3845", size = 1450891 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/30/3d/64ad57c803f1fa1e963a7946b6e0fea4a70df53c1a7fed304586539c2bac/pytest-8.3.5-py3-none-any.whl", hash = "sha256:c69214aa47deac29fad6c2a4f590b9c4a9fdb16a403176fe154b79c0b4d4d820", size = 343634 },
 ]
 
 [[package]]
@@ -208,14 +250,45 @@ wheels = [
 ]
 
 [[package]]
+name = "ruff"
+version = "0.11.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/77/2b/7ca27e854d92df5e681e6527dc0f9254c9dc06c8408317893cf96c851cdd/ruff-0.11.0.tar.gz", hash = "sha256:e55c620690a4a7ee6f1cccb256ec2157dc597d109400ae75bbf944fc9d6462e2", size = 3799407 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/48/40/3d0340a9e5edc77d37852c0cd98c5985a5a8081fc3befaeb2ae90aaafd2b/ruff-0.11.0-py3-none-linux_armv6l.whl", hash = "sha256:dc67e32bc3b29557513eb7eeabb23efdb25753684b913bebb8a0c62495095acb", size = 10098158 },
+    { url = "https://files.pythonhosted.org/packages/ec/a9/d8f5abb3b87b973b007649ac7bf63665a05b2ae2b2af39217b09f52abbbf/ruff-0.11.0-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:38c23fd9bdec4eb437b4c1e3595905a0a8edfccd63a790f818b28c78fe345639", size = 10879071 },
+    { url = "https://files.pythonhosted.org/packages/ab/62/aaa198614c6211677913ec480415c5e6509586d7b796356cec73a2f8a3e6/ruff-0.11.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:7c8661b0be91a38bd56db593e9331beaf9064a79028adee2d5f392674bbc5e88", size = 10247944 },
+    { url = "https://files.pythonhosted.org/packages/9f/52/59e0a9f2cf1ce5e6cbe336b6dd0144725c8ea3b97cac60688f4e7880bf13/ruff-0.11.0-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b6c0e8d3d2db7e9f6efd884f44b8dc542d5b6b590fc4bb334fdbc624d93a29a2", size = 10421725 },
+    { url = "https://files.pythonhosted.org/packages/a6/c3/dcd71acc6dff72ce66d13f4be5bca1dbed4db678dff2f0f6f307b04e5c02/ruff-0.11.0-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:3c3156d3f4b42e57247275a0a7e15a851c165a4fc89c5e8fa30ea6da4f7407b8", size = 9954435 },
+    { url = "https://files.pythonhosted.org/packages/a6/9a/342d336c7c52dbd136dee97d4c7797e66c3f92df804f8f3b30da59b92e9c/ruff-0.11.0-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:490b1e147c1260545f6d041c4092483e3f6d8eba81dc2875eaebcf9140b53905", size = 11492664 },
+    { url = "https://files.pythonhosted.org/packages/84/35/6e7defd2d7ca95cc385ac1bd9f7f2e4a61b9cc35d60a263aebc8e590c462/ruff-0.11.0-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:1bc09a7419e09662983b1312f6fa5dab829d6ab5d11f18c3760be7ca521c9329", size = 12207856 },
+    { url = "https://files.pythonhosted.org/packages/22/78/da669c8731bacf40001c880ada6d31bcfb81f89cc996230c3b80d319993e/ruff-0.11.0-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:bcfa478daf61ac8002214eb2ca5f3e9365048506a9d52b11bea3ecea822bb844", size = 11645156 },
+    { url = "https://files.pythonhosted.org/packages/ee/47/e27d17d83530a208f4a9ab2e94f758574a04c51e492aa58f91a3ed7cbbcb/ruff-0.11.0-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:6fbb2aed66fe742a6a3a0075ed467a459b7cedc5ae01008340075909d819df1e", size = 13884167 },
+    { url = "https://files.pythonhosted.org/packages/9f/5e/42ffbb0a5d4b07bbc642b7d58357b4e19a0f4774275ca6ca7d1f7b5452cd/ruff-0.11.0-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:92c0c1ff014351c0b0cdfdb1e35fa83b780f1e065667167bb9502d47ca41e6db", size = 11348311 },
+    { url = "https://files.pythonhosted.org/packages/c8/51/dc3ce0c5ce1a586727a3444a32f98b83ba99599bb1ebca29d9302886e87f/ruff-0.11.0-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:e4fd5ff5de5f83e0458a138e8a869c7c5e907541aec32b707f57cf9a5e124445", size = 10305039 },
+    { url = "https://files.pythonhosted.org/packages/60/e0/475f0c2f26280f46f2d6d1df1ba96b3399e0234cf368cc4c88e6ad10dcd9/ruff-0.11.0-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:96bc89a5c5fd21a04939773f9e0e276308be0935de06845110f43fd5c2e4ead7", size = 9937939 },
+    { url = "https://files.pythonhosted.org/packages/e2/d3/3e61b7fd3e9cdd1e5b8c7ac188bec12975c824e51c5cd3d64caf81b0331e/ruff-0.11.0-py3-none-musllinux_1_2_i686.whl", hash = "sha256:a9352b9d767889ec5df1483f94870564e8102d4d7e99da52ebf564b882cdc2c7", size = 10923259 },
+    { url = "https://files.pythonhosted.org/packages/30/32/cd74149ebb40b62ddd14bd2d1842149aeb7f74191fb0f49bd45c76909ff2/ruff-0.11.0-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:049a191969a10897fe052ef9cc7491b3ef6de79acd7790af7d7897b7a9bfbcb6", size = 11406212 },
+    { url = "https://files.pythonhosted.org/packages/00/ef/033022a6b104be32e899b00de704d7c6d1723a54d4c9e09d147368f14b62/ruff-0.11.0-py3-none-win32.whl", hash = "sha256:3191e9116b6b5bbe187447656f0c8526f0d36b6fd89ad78ccaad6bdc2fad7df2", size = 10310905 },
+    { url = "https://files.pythonhosted.org/packages/ed/8a/163f2e78c37757d035bd56cd60c8d96312904ca4a6deeab8442d7b3cbf89/ruff-0.11.0-py3-none-win_amd64.whl", hash = "sha256:c58bfa00e740ca0a6c43d41fb004cd22d165302f360aaa56f7126d544db31a21", size = 11411730 },
+    { url = "https://files.pythonhosted.org/packages/4e/f7/096f6efabe69b49d7ca61052fc70289c05d8d35735c137ef5ba5ef423662/ruff-0.11.0-py3-none-win_arm64.whl", hash = "sha256:868364fc23f5aa122b00c6f794211e85f7e78f5dffdf7c590ab90b8c4e69b657", size = 10538956 },
+]
+
+[[package]]
 name = "scanner"
 source = { virtual = "." }
 dependencies = [
     { name = "check-jsonschema" },
+    { name = "pytest" },
+    { name = "ruff" },
 ]
 
 [package.metadata]
-requires-dist = [{ name = "check-jsonschema", specifier = "==0.31.0" }]
+requires-dist = [
+    { name = "check-jsonschema", specifier = "==0.31.0" },
+    { name = "pytest", specifier = "==8.3.5" },
+    { name = "ruff", specifier = "==0.11.0" },
+]
 
 [[package]]
 name = "urllib3"


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes several changes to improve Python code checks and dependencies management. The most important changes involve adding a new job to the GitHub Actions workflow for running Python code checks, updating dependencies in multiple `pyproject.toml` files, and adding Ruff configuration for linting and formatting.

### Improvements to Python Code Checks:

* [`.github/workflows/code-checks.yml`](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4R246-R281): Added a new job `run-tests-python-code-checks` to run Python code checks using Ruff, including steps for setting up dependencies, generating and uploading Ruff Sarif analysis results, and checking Python code format and linting.

### Dependency Updates:

* [`diagrams/pyproject.toml`](diffhunk://#diff-72922956af93dcd7c4684bd443145f9049c7ae41910c86826ce0a1f46d04d873L11-R11): Updated `required-version` of `uv` from `0.6.8` to `0.6.10`.
* [`scanner/pyproject.toml`](diffhunk://#diff-a3b82d49d76ebad61ba78436003c53e4907ae972476a9531807ceabd157d7586L22-R22): Updated `required-version` of `uv` from `0.6.8` to `0.6.10`.
* [`tests/pyproject.toml`](diffhunk://#diff-03049af3cb225ee5c5f22bc10731df89191cc762ad9ca9aa4cb7d3a87786ac8dL5-R55): Updated dependencies to include `pytest==8.3.5` and `ruff==0.11.0`, and updated `required-version` of `uv` from `0.6.8` to `0.6.10`. Added extensive Ruff configuration for linting and formatting.

### Ruff Configuration:

* [`tests/tests.just`](diffhunk://#diff-83e2fb4528694cfa62c213eefec53e6aeee0353030bf91ad4f830e69854b7918R9-R39): Added new commands for fixing and checking Ruff issues, including `ruff-fix`, `ruff-checks`, `ruff-lint-check`, `ruff-lint-fix`, `ruff-format-check`, and `ruff-format-fix`.

Fixes #114
