### PR TITLE
Add NPM Dependabot Configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -37,3 +37,18 @@ updates:
         update-types:
           - "patch"
           - "minor"
+
+  - package-ecosystem: "npm"
+    directory: "dashboard"
+    schedule:
+      interval: "daily"
+      time: "01:00"
+      timezone: "Europe/London"
+    target-branch: "main"
+    groups:
+      typescript:
+        patterns:
+          - "*"
+        update-types:
+          - "patch"
+          - "minor"


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes an update to the `.github/dependabot.yml` file to add a new configuration for managing dependencies in the `dashboard` directory.

Configuration updates:

* Added a new `package-ecosystem` for `npm` in the `dashboard` directory with a daily update schedule set to 01:00 in the Europe/London timezone.

Fixes #118
