### PR TITLE
Bump setup-uv to v6.0.0

### DIFF
--- a/.github/actions/setup-diagrams-dependencies/action.yml
+++ b/.github/actions/setup-diagrams-dependencies/action.yml
@@ -5,7 +5,7 @@ runs:
   using: "composite"
   steps:
     - name: Install Python and UV
-      uses: astral-sh/setup-uv@f94ec6bedd8674c4426838e6b50417d36b6ab231 # v5.3.1
+      uses: astral-sh/setup-uv@c7f87aa956e4c323abf06d5dec078e358f6b4d04 # v6.0.0
       with:
         pyproject-file: "diagrams/pyproject.toml"
         enable-cache: true

--- a/.github/actions/setup-diagrams-dependencies/action.yml
+++ b/.github/actions/setup-diagrams-dependencies/action.yml
@@ -7,8 +7,7 @@ runs:
     - name: Install Python and UV
       uses: astral-sh/setup-uv@c7f87aa956e4c323abf06d5dec078e358f6b4d04 # v6.0.0
       with:
-        pyproject-file: "diagrams/pyproject.toml"
-        enable-cache: true
+        working-directory: "diagrams"
     - name: Set up Just
       uses: extractions/setup-just@dd310ad5a97d8e7b41793f8ef055398d51ad4de6 # v2.0.0
     - name: Install Python Dependencies

--- a/.github/actions/setup-scanner-dependencies/action.yml
+++ b/.github/actions/setup-scanner-dependencies/action.yml
@@ -7,8 +7,7 @@ runs:
     - name: Install Python and UV
       uses: astral-sh/setup-uv@c7f87aa956e4c323abf06d5dec078e358f6b4d04 # v6.0.0
       with:
-        pyproject-file: "scanner/pyproject.toml"
-        enable-cache: true
+        working-directory: "scanner"
     - name: Set up Just
       uses: extractions/setup-just@dd310ad5a97d8e7b41793f8ef055398d51ad4de6 # v2.0.0
     - name: Install Python Dependencies

--- a/.github/actions/setup-scanner-dependencies/action.yml
+++ b/.github/actions/setup-scanner-dependencies/action.yml
@@ -5,7 +5,7 @@ runs:
   using: "composite"
   steps:
     - name: Install Python and UV
-      uses: astral-sh/setup-uv@f94ec6bedd8674c4426838e6b50417d36b6ab231 # v5.3.1
+      uses: astral-sh/setup-uv@c7f87aa956e4c323abf06d5dec078e358f6b4d04 # v6.0.0
       with:
         pyproject-file: "scanner/pyproject.toml"
         enable-cache: true

--- a/.github/actions/setup-tests-dependencies/action.yml
+++ b/.github/actions/setup-tests-dependencies/action.yml
@@ -5,7 +5,7 @@ runs:
   using: "composite"
   steps:
     - name: Install Python and UV
-      uses: astral-sh/setup-uv@f94ec6bedd8674c4426838e6b50417d36b6ab231 # v5.3.1
+      uses: astral-sh/setup-uv@c7f87aa956e4c323abf06d5dec078e358f6b4d04 # v6.0.0
       with:
         pyproject-file: "tests/pyproject.toml"
         enable-cache: true

--- a/.github/actions/setup-tests-dependencies/action.yml
+++ b/.github/actions/setup-tests-dependencies/action.yml
@@ -7,8 +7,7 @@ runs:
     - name: Install Python and UV
       uses: astral-sh/setup-uv@c7f87aa956e4c323abf06d5dec078e358f6b4d04 # v6.0.0
       with:
-        pyproject-file: "tests/pyproject.toml"
-        enable-cache: true
+        working-directory: "tests"
     - name: Set up Just
       uses: extractions/setup-just@dd310ad5a97d8e7b41793f8ef055398d51ad4de6 # v2.0.0
     - name: Install Python Dependencies

--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -121,8 +121,6 @@ jobs:
           persist-credentials: false
       - name: Install the latest version of uv
         uses: astral-sh/setup-uv@c7f87aa956e4c323abf06d5dec078e358f6b4d04 # v6.0.0
-        with:
-          version: "latest"
       - name: Run Lefthook Validate
         run: uvx lefthook validate
 

--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -120,7 +120,7 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - name: Install the latest version of uv
-        uses: astral-sh/setup-uv@f94ec6bedd8674c4426838e6b50417d36b6ab231 # v5.3.1
+        uses: astral-sh/setup-uv@c7f87aa956e4c323abf06d5dec078e358f6b4d04 # v6.0.0
         with:
           version: "latest"
       - name: Run Lefthook Validate


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates the version of the `astral-sh/setup-uv` action used across multiple GitHub Actions workflows to version `v6.0.0`. Additionally, it simplifies the configuration for Python dependency installation by replacing `pyproject-file` and `enable-cache` with `working-directory` in specific workflows.

### Updates to GitHub Actions workflows:

* **Upgrade `setup-uv` action to v6.0.0**:
  - Updated the `astral-sh/setup-uv` action from version `v5.3.1` to `v6.0.0` in the following files:
    - `.github/actions/setup-diagrams-dependencies/action.yml`
    - `.github/actions/setup-scanner-dependencies/action.yml`
    - `.github/actions/setup-tests-dependencies/action.yml`
    - `.github/workflows/code-checks.yml`

* **Simplify Python dependency installation configuration**:
  - Replaced `pyproject-file` and `enable-cache` options with `working-directory` in:
    - `.github/actions/setup-diagrams-dependencies/action.yml`
    - `.github/actions/setup-scanner-dependencies/action.yml`
    - `.github/actions/setup-tests-dependencies/action.yml`