### PR TITLE
Add Zizmor Configuration

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -54,7 +54,7 @@ lefthook-validate:
 
 # Run zizmor checking
 zizmor-check:
-    zizmor .
+    zizmor . --pedantic --persona=pedantic
 
 # ------------------------------------------------------------------------------
 # Pinact


### PR DESCRIPTION
# Pull Request

## Description

This pull request introduces a small enhancement to the `lefthook-validate:` section in the `Justfile`. The change updates the `zizmor-check` command to include additional flags for stricter validation and a specific persona.

* [`Justfile`](diffhunk://#diff-2f90408c2b0302b1cdb7f5d634114750837f940fa82d13057d9c18d0170a7e5cL57-R57): Updated the `zizmor-check` command to include the `--pedantic` flag and set the `--persona` option to `pedantic` for more rigorous checks.