### PR TITLE
Fix Zizmor SARIF Command

### DIFF
--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -98,10 +98,12 @@ jobs:
         with:
           fetch-depth: 0
           persist-credentials: false
-      - name: Setup Scanner Dependencies
-        uses: ./.github/actions/setup-scanner-dependencies
+      - name: Install the latest version of uv
+        uses: astral-sh/setup-uv@6b9c6063abd6010835644d4c2e1bef4cf5cd0fca # v6.0.1
+      - name: Set up Just
+        uses: extractions/setup-just@e33e0265a09d6d736e2ee1e0eb685ef1de4669ff # v3
       - name: Run zizmor 🌈
-        run: uv --project scanner run zizmor --format sarif . > results.sarif
+        run: just zizmor-check-sarif
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Upload SARIF file
@@ -109,7 +111,6 @@ jobs:
         with:
           sarif_file: results.sarif
           category: zizmor
-
   lefthook-validate:
     name: Lefthook Validate
     runs-on: ubuntu-latest

--- a/Justfile
+++ b/Justfile
@@ -54,7 +54,11 @@ lefthook-validate:
 
 # Run zizmor checking
 zizmor-check:
-    zizmor . --pedantic --persona=pedantic
+    uvx zizmor . --persona=pedantic
+
+# Run zizmor checking with sarif output
+zizmor-check-sarif:
+    uvx zizmor . --persona=pedantic --format sarif > results.sarif
 
 # ------------------------------------------------------------------------------
 # Pinact


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates the workflow configuration and the `Justfile` to integrate new tools (`uv` and `Just`) and refactor how the `zizmor` checks are executed. The most notable changes include replacing the scanner setup and execution steps with `uv` and `Just`, and adding a new `Just` recipe for `zizmor` checks with SARIF output.

### Workflow updates:

* [`.github/workflows/code-checks.yml`](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L101-L112): Replaced the custom `setup-scanner-dependencies` action with the installation of `uv` (`astral-sh/setup-uv@6b9c6063abd6010835644d4c2e1bef4cf5cd0fca`) and `Just` (`extractions/setup-just@e33e0265a09d6d736e2ee1e0eb685ef1de4669ff`). Updated the `Run zizmor` step to use the new `just zizmor-check-sarif` command instead of directly invoking `uv`.

### `Justfile` updates:

* [`Justfile`](diffhunk://#diff-2f90408c2b0302b1cdb7f5d634114750837f940fa82d13057d9c18d0170a7e5cL57-R61): Added a new recipe `zizmor-check-sarif` to run `zizmor` with SARIF output using `uvx`. Updated the existing `zizmor-check` recipe to use `uvx` instead of calling `zizmor` directly.