### PR TITLE
Change Jobs to Common Pull Request Tasks

### DIFF
--- a/.github/workflows/pull-request-tasks.yml
+++ b/.github/workflows/pull-request-tasks.yml
@@ -8,45 +8,10 @@ permissions:
   pull-requests: read
 
 jobs:
-  labeller:
-    name: Label Pull Request
-    runs-on: ubuntu-latest
+  common-pull-request-tasks:
+    name: Common Pull Request Tasks
     permissions:
       pull-requests: write
-    steps:
-      - name: Label Pull Request
-        uses: actions/labeler@8558fd74291d67161a8a78ce36a881fa63b766a9 # v5.0.0
-        with:
-          repo-token: "${{ secrets.GITHUB_TOKEN }}"
-          configuration-path: .github/other-configurations/labeller.yml
-          sync-labels: true
-      - name: Add Size Labels
-        uses: pascalgn/size-label-action@f8edde36b3be04b4f65dcfead05dc8691b374348 # v0.5.5
-        env:
-          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
-        with:
-          sizes: >
-            {
-              "0": "XS",
-              "40": "S",
-              "100": "M",
-              "200": "L",
-              "800": "XL",
-              "2000": "XXL"
-            }
-
-  dependency-review:
-    name: Dependency Review
-    runs-on: ubuntu-latest
-    permissions:
-      pull-requests: write
-    steps:
-      - name: Checkout Repository
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-        with:
-          fetch-depth: 0
-          persist-credentials: false
-      - name: Dependency Review
-        uses: actions/dependency-review-action@da24556b548a50705dd671f47852072ea4c105d9 # v4.7.1
-        with:
-          comment-summary-in-pr: on-failure
+    uses: JackPlowman/reusable-workflows/.github/workflows/common-pull-request-tasks.yml@14445779094fde883fdb9f65946fcae6c25f46c0 # v2025.05.14.01
+    secrets:
+      workflow_github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
# Pull Request

## Description

This pull request simplifies the workflow configuration in `.github/workflows/pull-request-tasks.yml` by consolidating multiple jobs into a reusable workflow. The changes improve maintainability by replacing individual job definitions with a single reference to a reusable workflow.

### Workflow simplification:
* Replaced the `labeller` and `dependency-review` jobs with a single `common-pull-request-tasks` job that uses a reusable workflow from `JackPlowman/reusable-workflows`. This eliminates the need for inline definitions of steps like labeling pull requests and performing dependency reviews.
