### PR TITLE
Migrate Sync Labels to Common Sync Labels

### DIFF
--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -17,4 +17,4 @@ jobs:
       pull-requests: write
     uses: JackPlowman/reusable-workflows/.github/workflows/common-sync-labels.yml@1fc46e17341e1306bfff74123efac880aff16d48 # v2025.05.17.04
     secrets:
-      workflow_github_token: ${{ secrets.GH_TOKEN }}
+      workflow_github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -6,25 +6,15 @@ on:
       - main
     paths:
       - .github/other-configurations/labels.yml
+  workflow_dispatch:
 
-permissions:
-  contents: read
-  pull-requests: read
+permissions: {}
 
 jobs:
   configure-labels:
-    runs-on: ubuntu-latest
     permissions:
+      contents: read
       pull-requests: write
-    steps:
-      - name: Checkout Repository
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-        with:
-          fetch-depth: 0
-          persist-credentials: false
-      - name: Sync labels
-        uses: micnncim/action-label-syncer@3abd5ab72fda571e69fffd97bd4e0033dd5f495c # v1.3.0
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          repository: ${{ github.repository }}
-          manifest: .github/other-configurations/labels.yml
+    uses: JackPlowman/reusable-workflows/.github/workflows/common-sync-labels.yml@1fc46e17341e1306bfff74123efac880aff16d48 # v2025.05.17.04
+    secrets:
+      workflow_github_token: ${{ secrets.GH_TOKEN }}


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates the `.github/workflows/sync-labels.yml` file to simplify the workflow configuration by using a reusable workflow and making adjustments to permissions and triggers.

### Workflow simplification:
* Replaced the inline job configuration with a reusable workflow, `common-sync-labels.yml`, from the `JackPlowman/reusable-workflows` repository. This change reduces redundancy and centralizes the label synchronization logic.

### Permissions adjustments:
* Changed the `permissions` block to an empty object (`{}`) at the workflow level and specified job-level permissions (`contents: read` and `pull-requests: write`) for better security and clarity.

### Trigger updates:
* Added `workflow_dispatch` as a trigger, allowing manual execution of the workflow.