### PR TITLE
Update Dependabot for Reusable Workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,7 +19,7 @@ updates:
           - "*"
         exclude-patterns:
           - "super-linter/super-linter"
-          - "JackPlowman/reusable-workflows/*"
+          - "JackPlowman/reusable-workflows"
         update-types:
           - "patch"
           - "minor"


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes a minor update to the `.github/dependabot.yml` file, refining the exclusion pattern for dependencies. The change removes the wildcard character from the exclusion pattern for `JackPlowman/reusable-workflows`.

* [`.github/dependabot.yml`](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28L22-R22): Updated the exclusion pattern for `JackPlowman/reusable-workflows` to exclude the entire directory instead of matching specific files within it.