### PR TITLE
chore: Add Dashboard Just Commands

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -1,3 +1,4 @@
+mod dashboard 'dashboard/dashboard.just'
 mod scanner 'scanner/scanner.just'
 mod tests 'tests/tests.just'
 
@@ -20,12 +21,14 @@ prettier-format:
 # Format Justfile
 format:
     just --fmt --unstable
+    just --fmt --unstable --justfile dashboard/dashboard.just
     just --fmt --unstable --justfile scanner/scanner.just
     just --fmt --unstable --justfile tests/tests.just
 
 # Check Justfile formatting
 format-check:
     just --fmt --check --unstable
+    just --fmt --check --unstable --justfile dashboard/dashboard.just
     just --fmt --check --unstable --justfile scanner/scanner.just
     just --fmt --check --unstable --justfile tests/tests.just
 

--- a/dashboard/dashboard.just
+++ b/dashboard/dashboard.just
@@ -1,0 +1,31 @@
+# ------------------------------------------------------------------------------
+# General Commands
+# ------------------------------------------------------------------------------
+
+# Install dependencies
+install:
+    npm install
+
+# Install dependencies in workflow
+ci:
+    npm ci
+
+# Lint typescript code with ESLint
+lint:
+    npx eslint .
+
+# Lint typescript code with ESLint and generate a SARIF file
+eslint-with-sarif:
+    npx eslint . --format @microsoft/eslint-formatter-sarif --output-file eslint-results.sarif
+
+# ------------------------------------------------------------------------------
+# Prettier
+# ------------------------------------------------------------------------------
+
+# Check if code is formatted correctly
+prettier-check:
+    npx prettier . --check
+
+# Format code with Prettier
+prettier-format:
+    npx prettier . --check --write


### PR DESCRIPTION
# Pull Request

## Description

This pull request introduces a new `dashboard/dashboard.just` file with commands for dependency management, linting, and code formatting, and integrates it into the existing `Justfile` structure. The changes ensure that the `dashboard` module has its own dedicated justfile and that it is included in formatting and format-checking workflows.

### Integration of `dashboard.just` into the `Justfile`:
* Added a reference to the new `dashboard/dashboard.just` in the `Justfile` using the `mod` directive.
* Updated the `format` and `format-check` targets in the `Justfile` to include commands for formatting and checking the `dashboard/dashboard.just` file.

### New `dashboard/dashboard.just` file:
* Introduced a new `dashboard/dashboard.just` file with commands for managing dependencies (`install`, `ci`), linting TypeScript code (`lint`, `eslint-with-sarif`), and formatting code with Prettier (`prettier-check`, `prettier-format`).
