### PR TITLE
ci: Add Scanner Output Scanning

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -38,3 +38,23 @@ jobs:
         with:
           name: output
           path: scanner/output.json
+
+  validate-scanner-output:
+    name: Validate Scanner Output
+    runs-on: ubuntu-latest
+    needs: run-scanner
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Setup Test Dependencies
+        uses: ./.github/actions/setup-tests-dependencies
+      - name: Download Artifact
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: output
+          path: tests/schema_validation
+      - name: Validate Schema
+        run: just tests::validate-schema


### PR DESCRIPTION
# Pull Request

## Description

This pull request adds a new job to the deployment workflow to validate the output of the scanner. The most important change is the introduction of the `validate-scanner-output` job, which ensures that the scanner's output adheres to the expected schema.

### Workflow Enhancements:
* [`.github/workflows/deploy.yml`](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3R41-R60): Added a new job, `validate-scanner-output`, to validate the scanner's output. This job runs after `run-scanner` and includes steps to check out the repository, set up test dependencies, download the scanner's output artifact, and validate its schema using the `just tests::validate-schema` command.
