### PR TITLE
ci: Allow deployment workflow to be triggered manually 

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
   schedule:
     - cron: "0 0 * * *"
+  workflow_dispatch:
 
 permissions:
   contents: read


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates the GitHub Actions workflow to allow manual triggering of the deployment workflow.

Workflow configuration changes:

* [`.github/workflows/deploy.yml`](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3R8): Added the `workflow_dispatch` event to the `on:` section, enabling the deployment workflow to be triggered manually.
