### PR TITLE
ci: Download output file to dashboard build step

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -72,6 +72,11 @@ jobs:
         with:
           fetch-depth: 0
           persist-credentials: false
+      - name: Download Artifact
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: output
+          path: dashboard/data
       - name: Set up Node.js with Cache
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,6 +3,5 @@
     "*/.pytest_cache/*": true,
     "*/__pycache__/*": true,
     "scanner/cloned_repositories/*": true
-  },
-  "codeQL.githubDatabase.download": "never"
+  }
 }

--- a/dashboard/.gitignore
+++ b/dashboard/.gitignore
@@ -22,3 +22,6 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+
+# Data file
+data/*.json


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes changes to streamline the deployment workflow, update project settings, and adjust `.gitignore` rules for the `dashboard` directory. The most important changes are grouped below:

### Deployment Workflow Enhancements:
* [`.github/workflows/deploy.yml`](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3R75-R79): Added a step to download an artifact named `output` into the `dashboard/data` directory using the `actions/download-artifact` action.

### Project Settings Updates:
* [`.vscode/settings.json`](diffhunk://#diff-a5de3e5871ffcc383a2294845bd3df25d3eeff6c29ad46e3a396577c413bf357L6-R6): Removed the `codeQL.githubDatabase.download` setting, which was previously set to `"never"`.

### Git Ignore Adjustments:
* [`dashboard/.gitignore`](diffhunk://#diff-cbf895551713379e47e8c8ce20dde1000972c48c3ff622b050ee2cf54f16d129R25-R27): Added a rule to ignore JSON files in the `data` directory (`data/*.json`).
