### PR TITLE
build: Add Repository Stats

### DIFF
--- a/scanner/app/__main__.py
+++ b/scanner/app/__main__.py
@@ -66,7 +66,17 @@ def generate_output(analysis: list[AnalysedRepository]) -> None:
         "total": {
             "lines": total_code_lines,
             "files": total_files,
-        }
+        },
+        "repositories": [
+            {
+                "name": repository["name"],
+                "summary": {
+                    "lines": repository["summary"].total_line_count,
+                    "files": repository["summary"].total_file_count,
+                },
+            }
+            for repository in analysis
+        ],
     }
     with Path("output.json").open("w", encoding="utf-8") as file:
         dump(dict_to_json, file, indent=4, ensure_ascii=False)

--- a/scanner/app/tests/test__main__.py
+++ b/scanner/app/tests/test__main__.py
@@ -91,10 +91,11 @@ def test_generate_output(mock_dump: MagicMock, mock_path: MagicMock) -> None:
     # Assert
     mock_dump.assert_called_once_with(
         {
-            "total": {
-                "lines": 300,
-                "files": 30,
-            }
+            "total": {"lines": 300, "files": 30},
+            "repositories": [
+                {"name": "repo1", "summary": {"lines": 100, "files": 10}},
+                {"name": "repo2", "summary": {"lines": 200, "files": 20}},
+            ],
         },
         mock_file,
         indent=4,

--- a/tests/schema_validation/output_schema.json
+++ b/tests/schema_validation/output_schema.json
@@ -16,6 +16,7 @@
     },
     "repositories": {
       "type": "array",
+      "additionalItems": false,
       "items": [
         {
           "type": "object",

--- a/tests/schema_validation/output_schema.json
+++ b/tests/schema_validation/output_schema.json
@@ -1,10 +1,8 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
-  "additionalProperties": false,
   "type": "object",
   "properties": {
     "total": {
-      "additionalProperties": false,
       "type": "object",
       "properties": {
         "lines": {
@@ -15,7 +13,33 @@
         }
       },
       "required": ["lines", "files"]
+    },
+    "repositories": {
+      "type": "array",
+      "items": [
+        {
+          "type": "object",
+          "properties": {
+            "name": {
+              "type": "string"
+            },
+            "summary": {
+              "type": "object",
+              "properties": {
+                "lines": {
+                  "type": "integer"
+                },
+                "files": {
+                  "type": "integer"
+                }
+              },
+              "required": ["lines", "files"]
+            }
+          },
+          "required": ["name", "summary"]
+        }
+      ]
     }
   },
-  "required": ["total"]
+  "required": ["total", "repositories"]
 }


### PR DESCRIPTION
# Pull Request

## Description

This pull request enhances the output of the `generate_output` function to include repository-level details and updates the corresponding test and schema to support this new structure. The most important changes include modifying the output JSON format, updating the test case to validate the new structure, and adjusting the schema to ensure compliance.

### Enhancements to output structure:
* [`scanner/app/__main__.py`](diffhunk://#diff-e370c8f7bf64354b82fe45c59db166c3b80722cbe29d17342bad06377b071639R69-R79): Updated the `generate_output` function to include a `repositories` field in the output JSON, which provides a summary of lines and files for each analyzed repository.

### Test updates:
* [`scanner/app/tests/test__main__.py`](diffhunk://#diff-3769f9e724e6d1500834f25a77822294bd74942236eba545f365f859956d0da8L94-R98): Modified the `test_generate_output` test to validate the new `repositories` field in the JSON output, ensuring that repository-level summaries are correctly generated.

### Schema updates:
* [`tests/schema_validation/output_schema.json`](diffhunk://#diff-3a3c09ea2acf72d134b7171cfdebb3d23e994039d4037c5f3292786b70ade0f3L3-L7): Updated the JSON schema to include a `repositories` field, which is an array of objects containing `name` and `summary` properties. This ensures the output adheres to the new structure. [[1]](diffhunk://#diff-3a3c09ea2acf72d134b7171cfdebb3d23e994039d4037c5f3292786b70ade0f3L3-L7) [[2]](diffhunk://#diff-3a3c09ea2acf72d134b7171cfdebb3d23e994039d4037c5f3292786b70ade0f3R16-R44)
