### PR TITLE
Update Reusable Workflows

### DIFF
--- a/.github/actions/setup-scanner-dependencies/action.yml
+++ b/.github/actions/setup-scanner-dependencies/action.yml
@@ -5,7 +5,7 @@ runs:
   using: "composite"
   steps:
     - name: Install Python and UV
-      uses: astral-sh/setup-uv@6b9c6063abd6010835644d4c2e1bef4cf5cd0fca # v6.0.1
+      uses: astral-sh/setup-uv@f0ec1fc3b38f5e7cd731bb6ce540c5af426746bb # v6.1.0
       with:
         working-directory: "scanner"
     - name: Set up Just

--- a/.github/actions/setup-tests-dependencies/action.yml
+++ b/.github/actions/setup-tests-dependencies/action.yml
@@ -5,7 +5,7 @@ runs:
   using: "composite"
   steps:
     - name: Install Python and UV
-      uses: astral-sh/setup-uv@6b9c6063abd6010835644d4c2e1bef4cf5cd0fca # v6.0.1
+      uses: astral-sh/setup-uv@f0ec1fc3b38f5e7cd731bb6ce540c5af426746bb # v6.1.0
       with:
         working-directory: "tests"
     - name: Set up Just

--- a/.github/workflows/clean-caches.yml
+++ b/.github/workflows/clean-caches.yml
@@ -12,6 +12,6 @@ jobs:
     name: Clean Caches
     permissions:
       contents: read
-    uses: JackPlowman/reusable-workflows/.github/workflows/common-clean-caches.yml@72df376b6d16d40834a212c93d2869295e4d9b39 # v2025.05.24.02
+    uses: JackPlowman/reusable-workflows/.github/workflows/common-clean-caches.yml@5449fecafeab1261b3267ab11f076ff5ed3bd935 # v2025.06.06.01
     secrets:
       workflow_github_token: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -56,6 +56,7 @@ jobs:
     name: Common Code Checks
     permissions:
       contents: read
+      actions: read
       pull-requests: write
       security-events: write
     uses: JackPlowman/reusable-workflows/.github/workflows/common-code-checks.yml@72df376b6d16d40834a212c93d2869295e4d9b39 # v2025.05.24.02

--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -59,7 +59,7 @@ jobs:
       actions: read
       pull-requests: write
       security-events: write
-    uses: JackPlowman/reusable-workflows/.github/workflows/common-code-checks.yml@72df376b6d16d40834a212c93d2869295e4d9b39 # v2025.05.24.02
+    uses: JackPlowman/reusable-workflows/.github/workflows/common-code-checks.yml@5449fecafeab1261b3267ab11f076ff5ed3bd935 # v2025.06.06.01
     secrets:
       workflow_github_token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -71,7 +71,7 @@ jobs:
     strategy:
       matrix:
         language: [actions, typescript, python]
-    uses: JackPlowman/reusable-workflows/.github/workflows/codeql-analysis.yml@72df376b6d16d40834a212c93d2869295e4d9b39 # v2025.05.24.02
+    uses: JackPlowman/reusable-workflows/.github/workflows/codeql-analysis.yml@5449fecafeab1261b3267ab11f076ff5ed3bd935 # v2025.06.06.01
     with:
       language: ${{ matrix.language }}
 
@@ -115,7 +115,7 @@ jobs:
           RUFF_OUTPUT_FILE: "ruff-results.sarif"
         continue-on-error: true
       - name: Upload Ruff analysis results to GitHub
-        uses: github/codeql-action/upload-sarif@ff0a06e83cb2de871e5a09832bc6a81e7276941f # v3.28.18
+        uses: github/codeql-action/upload-sarif@fca7ace96b7d713c7035871441bd52efbe39e27e # v3.28.19
         with:
           sarif_file: scanner/ruff-results.sarif
           wait-for-processing: true
@@ -153,7 +153,7 @@ jobs:
           RUFF_OUTPUT_FILE: "ruff-results.sarif"
         continue-on-error: true
       - name: Upload Ruff analysis results to GitHub
-        uses: github/codeql-action/upload-sarif@ff0a06e83cb2de871e5a09832bc6a81e7276941f # v3.28.18
+        uses: github/codeql-action/upload-sarif@fca7ace96b7d713c7035871441bd52efbe39e27e # v3.28.19
         with:
           sarif_file: tests/ruff-results.sarif
           wait-for-processing: true

--- a/.github/workflows/pull-request-tasks.yml
+++ b/.github/workflows/pull-request-tasks.yml
@@ -12,6 +12,6 @@ jobs:
     name: Common Pull Request Tasks
     permissions:
       pull-requests: write
-    uses: JackPlowman/reusable-workflows/.github/workflows/common-pull-request-tasks.yml@72df376b6d16d40834a212c93d2869295e4d9b39 # v2025.05.24.02
+    uses: JackPlowman/reusable-workflows/.github/workflows/common-pull-request-tasks.yml@5449fecafeab1261b3267ab11f076ff5ed3bd935 # v2025.06.06.01
     secrets:
       workflow_github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -15,6 +15,6 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
-    uses: JackPlowman/reusable-workflows/.github/workflows/common-sync-labels.yml@72df376b6d16d40834a212c93d2869295e4d9b39 # v2025.05.24.02
+    uses: JackPlowman/reusable-workflows/.github/workflows/common-sync-labels.yml@5449fecafeab1261b3267ab11f076ff5ed3bd935 # v2025.06.06.01
     secrets:
       workflow_github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates dependencies and reusable workflows across various GitHub Actions and workflows. The changes ensure compatibility with newer versions and improve functionality where applicable. 

### Dependency Updates:
* Updated `astral-sh/setup-uv` in `.github/actions/setup-scanner-dependencies/action.yml` and `.github/actions/setup-tests-dependencies/action.yml` from `v6.0.1` to `v6.1.0`. [[1]](diffhunk://#diff-610971f720595f0388265cdbe9219f6695522574e4cab7966faf1136d8393dbdL8-R8) [[2]](diffhunk://#diff-263e089eb2c5a46d8ce6caaccaaaf176722ae4e8da320d6cd2b779fa67c6ffcdL8-R8)
* Updated `github/codeql-action/upload-sarif` in `.github/workflows/code-checks.yml` from `v3.28.18` to `v3.28.19` for uploading Ruff analysis results. [[1]](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L117-R118) [[2]](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L155-R156)

### Reusable Workflow Updates:
* Updated reusable workflow references (`common-clean-caches.yml`, `common-code-checks.yml`, `codeql-analysis.yml`, `common-pull-request-tasks.yml`, and `common-sync-labels.yml`) across multiple workflow files to the latest version `v2025.06.06.01`. [[1]](diffhunk://#diff-d0394e4336a74cdfc1d4cff05d056b893ac7ff922eacf4448e104a754f386b8dL15-R15) [[2]](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4R59-R62) [[3]](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L73-R74) [[4]](diffhunk://#diff-ba6496a5b7a58ac3681ed047691dc32281cc7d548fff1d41201babbd65ad45cfL15-R15) [[5]](diffhunk://#diff-a877ed9f27d115d95934fd904f2475dcec6ce4125da686dd5b3c75a696fff1c6L18-R18)

### Permissions Update:
* Added `actions: read` permission in `.github/workflows/code-checks.yml` to enhance security and functionality for the Common Code Checks workflow.