### PR TITLE
Set specific Python versions

### DIFF
--- a/scanner/pyproject.toml
+++ b/scanner/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "scanner"
 dynamic = ["version"]
-requires-python = "~=3.13"
+requires-python = "~=3.13.0"
 dependencies = [
   "gitpython==3.1.44",
   "pygithub==2.6.1",

--- a/scanner/uv.lock
+++ b/scanner/uv.lock
@@ -1,6 +1,6 @@
 version = 1
 revision = 2
-requires-python = ">=3.13, <4"
+requires-python = "==3.13.*"
 
 [[package]]
 name = "certifi"

--- a/tests/pyproject.toml
+++ b/tests/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "scanner"
 dynamic = ["version"]
-requires-python = "~=3.13"
+requires-python = "~=3.13.0"
 dependencies = [
   "check-jsonschema==0.33.0",
   "pytest==8.4.1",

--- a/tests/uv.lock
+++ b/tests/uv.lock
@@ -1,6 +1,6 @@
 version = 1
 revision = 2
-requires-python = ">=3.13, <4"
+requires-python = "==3.13.*"
 
 [[package]]
 name = "attrs"


### PR DESCRIPTION
# Pull Request

## Description

This pull request makes a minor update to the Python version specification in the `pyproject.toml` files for both the `scanner` and `tests` projects. The change ensures the version is explicitly defined as `~=3.13.0` instead of `~=3.13`.

### Python version specification update:

* [`scanner/pyproject.toml`](diffhunk://#diff-a3b82d49d76ebad61ba78436003c53e4907ae972476a9531807ceabd157d7586L4-R4): Updated `requires-python` to explicitly specify version `~=3.13.0`.
* [`tests/pyproject.toml`](diffhunk://#diff-03049af3cb225ee5c5f22bc10731df89191cc762ad9ca9aa4cb7d3a87786ac8dL4-R4): Updated `requires-python` to explicitly specify version `~=3.13.0`.