### PR TITLE
Update python .gitignore

### DIFF
--- a/scanner/.gitignore
+++ b/scanner/.gitignore
@@ -1,6 +1,6 @@
 # Byte-compiled / optimized / DLL files
 __pycache__/
-*.py[cod]
+*.py[codz]
 *$py.class
 
 # C extensions
@@ -46,7 +46,7 @@ htmlcov/
 nosetests.xml
 coverage.xml
 *.cover
-*.py,cover
+*.py.cover
 .hypothesis/
 .pytest_cache/
 cover/
@@ -106,16 +106,23 @@ ipython_config.py
 #   commonly ignored for libraries.
 #   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
 #poetry.lock
+#poetry.toml
 
 # pdm
 #   Similar to Pipfile.lock, it is generally recommended to include pdm.lock in version control.
+#   pdm recommends including project-wide configuration in pdm.toml, but excluding .pdm-python.
+#   https://pdm-project.org/en/latest/usage/project/#working-with-version-control
 #pdm.lock
-#   pdm stores project-wide configurations in .pdm.toml, but it is recommended to not include it
-#   in version control.
-#   https://pdm.fming.dev/latest/usage/project/#working-with-version-control
-.pdm.toml
+#pdm.toml
 .pdm-python
 .pdm-build/
+
+# pixi
+#   Similar to Pipfile.lock, it is generally recommended to include pixi.lock in version control.
+#pixi.lock
+#   Pixi creates a virtual environment in the .pixi directory, just like venv module creates one
+#   in the .venv directory. It is recommended not to include this directory in version control.
+.pixi
 
 # PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
 __pypackages__/
@@ -129,6 +136,7 @@ celerybeat.pid
 
 # Environments
 .env
+.envrc
 .venv
 env/
 venv/
@@ -167,12 +175,29 @@ cython_debug/
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
 
+# Abstra
+# Abstra is an AI-powered process automation framework.
+# Ignore directories containing user credentials, local state, and settings.
+# Learn more at https://abstra.io/docs
+.abstra/
+
+# Visual Studio Code
+#  Visual Studio Code specific template is maintained in a separate VisualStudioCode.gitignore
+#  that can be found at https://github.com/github/gitignore/blob/main/Global/VisualStudioCode.gitignore
+#  and can be added to the global gitignore or merged into this file. However, if you prefer,
+#  you could uncomment the following to ignore the entire vscode folder
+# .vscode/
+
 # Ruff stuff:
 .ruff_cache/
 
 # PyPI configuration file
 .pypirc
 
-# Custom
-cloned_repositories/*
-!cloned_repositories/.gitkeep
+# Marimo
+marimo/_static/
+marimo/_lsp/
+__marimo__/
+
+# Streamlit
+.streamlit/secrets.toml

--- a/scanner/pyproject.toml
+++ b/scanner/pyproject.toml
@@ -19,7 +19,7 @@ dev = [
 ]
 
 [tool.uv]
-required-version = "0.7.19"
+required-version = "0.7.20"
 package = false
 
 [tool.setuptools]

--- a/tests/pyproject.toml
+++ b/tests/pyproject.toml
@@ -10,7 +10,7 @@ dependencies = [
 ]
 
 [tool.uv]
-required-version = "0.7.19"
+required-version = "0.7.20"
 package = false
 
 [tool.ruff]


### PR DESCRIPTION
# Pull Request

## Description

This pull request primarily updates the `.gitignore` file in the `scanner` directory to include new patterns for ignoring files and directories, and updates the `required-version` of the `uv` tool in `pyproject.toml` files. Below is a categorized summary of the most important changes:

### Updates to `.gitignore`:

* Modified patterns for Python-related files to include `.py[codz]` and `.py.cover` instead of `.py[cod]` and `.py,cover` respectively (`scanner/.gitignore`) [[1]](diffhunk://#diff-6d8dbc8b73a623578740a992bab1259e06f7e3e5b1e6b272c9534b91097d6eb9L3-R3) [[2]](diffhunk://#diff-6d8dbc8b73a623578740a992bab1259e06f7e3e5b1e6b272c9534b91097d6eb9L49-R49).
* Added new entries for tools and environments, such as `.envrc`, `.pixi`, `.abstra/`, and `.streamlit/secrets.toml` (`scanner/.gitignore`) [[1]](diffhunk://#diff-6d8dbc8b73a623578740a992bab1259e06f7e3e5b1e6b272c9534b91097d6eb9R109-R126) [[2]](diffhunk://#diff-6d8dbc8b73a623578740a992bab1259e06f7e3e5b1e6b272c9534b91097d6eb9R139) [[3]](diffhunk://#diff-6d8dbc8b73a623578740a992bab1259e06f7e3e5b1e6b272c9534b91097d6eb9R178-R203).
* Removed custom entries for `cloned_repositories/*` and added entries for `marimo` directories (`scanner/.gitignore`).

### Dependency updates:

* Updated the `required-version` of the `uv` tool from `0.7.19` to `0.7.20` in both `scanner/pyproject.toml` and `tests/pyproject.toml` [[1]](diffhunk://#diff-a3b82d49d76ebad61ba78436003c53e4907ae972476a9531807ceabd157d7586L22-R22) [[2]](diffhunk://#diff-03049af3cb225ee5c5f22bc10731df89191cc762ad9ca9aa4cb7d3a87786ac8dL13-R13).