### PR TITLE
Move types to common folder

### DIFF
--- a/dashboard/components.json
+++ b/dashboard/components.json
@@ -14,6 +14,7 @@
     "components": "@/components",
     "utils": "@/lib/utils",
     "ui": "@/components/ui",
+    "types": "@/types",
     "lib": "@/lib",
     "hooks": "@/hooks"
   },

--- a/dashboard/src/App.tsx
+++ b/dashboard/src/App.tsx
@@ -1,8 +1,8 @@
 import AppSidebar from "@/components/app-sidebar";
 import Background from "@/components/background";
 import DataPane from "@/components/data-pane";
-import repoData from "../data/output.json";
 import { useState } from "react";
+import repoData from "../data/output.json";
 
 function App() {
   // Load repositories from JSON

--- a/dashboard/src/components/app-sidebar.tsx
+++ b/dashboard/src/components/app-sidebar.tsx
@@ -15,15 +15,17 @@ import {
   SidebarRail,
 } from "@/components/ui/sidebar";
 
+import { RepoStats } from "@/types/types";
+
 export default function AppSidebar({
   repositories,
   selectedRepo,
   onSelectRepo,
   ...props
 }: React.ComponentProps<typeof Sidebar> & {
-  repositories: Array<{ name: string; summary: any }>;
-  selectedRepo: { name: string; summary: any };
-  onSelectRepo: (repo: { name: string; summary: any }) => void;
+  repositories: Array<RepoStats>;
+  selectedRepo: RepoStats;
+  onSelectRepo: (repo: RepoStats) => void;
 }) {
   return (
     <Sidebar {...props}>

--- a/dashboard/src/components/data-pane.tsx
+++ b/dashboard/src/components/data-pane.tsx
@@ -1,80 +1,81 @@
-type LinesAndFilesChanged = {
-  lines: number;
-  files: number;
-}
+import { RepoStats } from "@/types/types";
+import React from "react";
 
-type RepoStats = {
-  name: string;
-  summary: LinesAndFilesChanged;
-}
-
-export default function DataPane({ repo }: { repo: RepoStats }): React.JSX.Element {
+export default function DataPane({
+  repo,
+}: {
+  repo: RepoStats;
+}): React.JSX.Element {
   return (
     <main className="relative z-10 flex-1 flex justify-center items-center">
-        <div className="bg-white rounded-xl shadow-lg border border-gray-200 p-10 flex flex-col gap-8 min-w-[850px] min-h-[500px]">
-          {/* Stat Cards */}
-          <div className="grid grid-cols-4 gap-4 mb-8">
-            <div className="bg-gray-100 rounded-lg flex flex-col items-center justify-center h-24 text-lg font-semibold border border-gray-300">
-              Total Files:
-              <span className="text-2xl font-bold mt-1">{repo.summary.files}</span>
-            </div>
-            <div className="bg-gray-100 rounded-lg flex flex-col items-center justify-center h-24 text-lg font-semibold border border-gray-300">
-              Total Lines:
-              <span className="text-2xl font-bold mt-1">{repo.summary.lines}</span>
-            </div>
-            <div className="bg-gray-100 rounded-lg flex flex-col items-center justify-center h-24 text-lg font-semibold border border-gray-300">
-              Repo Name:
-              <span className="text-2xl font-bold mt-1">{repo.name}</span>
-            </div>
-            <div className="bg-gray-100 rounded-lg h-24 border border-gray-300" />
+      <div className="bg-white rounded-xl shadow-lg border border-gray-200 p-10 flex flex-col gap-8 min-w-[850px] min-h-[500px]">
+        {/* Stat Cards */}
+        <div className="grid grid-cols-4 gap-4 mb-8">
+          <div className="bg-gray-100 rounded-lg flex flex-col items-center justify-center h-24 text-lg font-semibold border border-gray-300">
+            Total Files:
+            <span className="text-2xl font-bold mt-1">
+              {repo.summary.files}
+            </span>
           </div>
-          {/* Graphs */}
-          <div className="grid grid-cols-2 grid-rows-2 gap-8">
-            <div className="flex flex-col items-center">
-              <div className="w-56 h-32 bg-white border border-gray-300 rounded-lg flex items-center justify-center">
-                {/* Graph A Placeholder */}
-                <svg width="100%" height="100%" viewBox="0 0 220 90">
-                  <polyline
-                    points="10,80 40,60 70,70 100,50 130,60 160,40 190,20"
-                    fill="none"
-                    stroke="#FF7112"
-                    strokeWidth="3"
-                  />
-                </svg>
-              </div>
-              <span className="mt-2 text-base">Graph A</span>
-            </div>
-            <div className="flex flex-col items-center">
-              <div className="w-56 h-32 bg-white border border-gray-300 rounded-lg flex items-center justify-center">
-                {/* Graph B Placeholder */}
-                <svg width="100%" height="100%" viewBox="0 0 220 90">
-                  <polyline
-                    points="10,80 40,70 70,60 100,80 130,60 160,70 190,40"
-                    fill="none"
-                    stroke="#FF7112"
-                    strokeWidth="3"
-                  />
-                </svg>
-              </div>
-              <span className="mt-2 text-base">Graph B</span>
-            </div>
-            <div className="flex flex-col items-center">
-              <div className="w-56 h-32 bg-white border border-gray-300 rounded-lg flex items-center justify-center">
-                {/* Graph C Placeholder */}
-                <svg width="100%" height="100%" viewBox="0 0 220 90">
-                  <polyline
-                    points="10,80 40,60 70,80 100,60 130,80 160,60 190,40"
-                    fill="none"
-                    stroke="#FF7112"
-                    strokeWidth="3"
-                  />
-                </svg>
-              </div>
-              <span className="mt-2 text-base">Graph C</span>
-            </div>
-            <div />
+          <div className="bg-gray-100 rounded-lg flex flex-col items-center justify-center h-24 text-lg font-semibold border border-gray-300">
+            Total Lines:
+            <span className="text-2xl font-bold mt-1">
+              {repo.summary.lines}
+            </span>
           </div>
+          <div className="bg-gray-100 rounded-lg flex flex-col items-center justify-center h-24 text-lg font-semibold border border-gray-300">
+            Repo Name:
+            <span className="text-2xl font-bold mt-1">{repo.name}</span>
+          </div>
+          <div className="bg-gray-100 rounded-lg h-24 border border-gray-300" />
         </div>
-      </main>
+        {/* Graphs */}
+        <div className="grid grid-cols-2 grid-rows-2 gap-8">
+          <div className="flex flex-col items-center">
+            <div className="w-56 h-32 bg-white border border-gray-300 rounded-lg flex items-center justify-center">
+              {/* Graph A Placeholder */}
+              <svg width="100%" height="100%" viewBox="0 0 220 90">
+                <polyline
+                  points="10,80 40,60 70,70 100,50 130,60 160,40 190,20"
+                  fill="none"
+                  stroke="#FF7112"
+                  strokeWidth="3"
+                />
+              </svg>
+            </div>
+            <span className="mt-2 text-base">Graph A</span>
+          </div>
+          <div className="flex flex-col items-center">
+            <div className="w-56 h-32 bg-white border border-gray-300 rounded-lg flex items-center justify-center">
+              {/* Graph B Placeholder */}
+              <svg width="100%" height="100%" viewBox="0 0 220 90">
+                <polyline
+                  points="10,80 40,70 70,60 100,80 130,60 160,70 190,40"
+                  fill="none"
+                  stroke="#FF7112"
+                  strokeWidth="3"
+                />
+              </svg>
+            </div>
+            <span className="mt-2 text-base">Graph B</span>
+          </div>
+          <div className="flex flex-col items-center">
+            <div className="w-56 h-32 bg-white border border-gray-300 rounded-lg flex items-center justify-center">
+              {/* Graph C Placeholder */}
+              <svg width="100%" height="100%" viewBox="0 0 220 90">
+                <polyline
+                  points="10,80 40,60 70,80 100,60 130,80 160,60 190,40"
+                  fill="none"
+                  stroke="#FF7112"
+                  strokeWidth="3"
+                />
+              </svg>
+            </div>
+            <span className="mt-2 text-base">Graph C</span>
+          </div>
+          <div />
+        </div>
+      </div>
+    </main>
   );
 }

--- a/dashboard/src/types/types.ts
+++ b/dashboard/src/types/types.ts
@@ -1,0 +1,11 @@
+type LinesAndFilesChanged = {
+  lines: number;
+  files: number;
+};
+
+type RepoStats = {
+  name: string;
+  summary: LinesAndFilesChanged;
+};
+
+export type { LinesAndFilesChanged, RepoStats };


### PR DESCRIPTION
# Pull Request

## Description

This pull request introduces several changes to improve type safety and modularity in the `dashboard` project by centralizing type definitions and updating components to use the new shared types. The key updates include the addition of a new `types` module, refactoring components to use shared types, and minor import adjustments.

### Type Centralization and Refactoring:

* Added a new `types` module in `dashboard/src/types/types.ts` to define and export `LinesAndFilesChanged` and `RepoStats` types for reuse across the codebase.
* Updated `AppSidebar` to use the `RepoStats` type from the `types` module, replacing inline type definitions for `repositories`, `selectedRepo`, and `onSelectRepo`.
* Refactored `DataPane` to import and use the `RepoStats` type from the `types` module, removing its local type definitions.

### Import Adjustments:

* Added an alias for `types` in `dashboard/components.json` to simplify imports of shared types.
* Adjusted the import order in `App.tsx` to follow a consistent style, moving `repoData` import below React-related imports.