### PR TITLE
Only scan public repos

### DIFF
--- a/scanner/app/github_interactions.py
+++ b/scanner/app/github_interactions.py
@@ -45,7 +45,7 @@ def retrieve_repositories(configuration: Configuration) -> PaginatedList[Reposit
     """
     github = Github(configuration.github_token)
     repositories = github.search_repositories(
-        query=f"user:{configuration.repository_owner} archived:false"
+        query=f"user:{configuration.repository_owner} archived:false is:public"
     )
     logger.info(
         "Retrieved repositories to analyse",

--- a/scanner/app/tests/test_github_integrations.py
+++ b/scanner/app/tests/test_github_integrations.py
@@ -43,4 +43,7 @@ def test_retrieve_repositories(mock_github: MagicMock) -> None:
     repositories = retrieve_repositories(configuration)
     # Assert
     mock_github.assert_called_once_with(token)
+    mock_github.return_value.search_repositories.assert_called_once_with(
+        query="user:Test archived:false is:public"
+    )
     assert repositories == search_return


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes a small but important change to the `retrieve_repositories` function in `scanner/app/github_interactions.py`. The change updates the GitHub search query to include only public repositories.

* [`scanner/app/github_interactions.py`](diffhunk://#diff-bbf2817a31eaed4aae4b50147867d3ff15763d738479b2a92913900ed8bd4328L48-R48): Modified the `retrieve_repositories` function to filter repositories by adding `is:public` to the search query, ensuring only public repositories are retrieved.