### PR TITLE
Update Reusable Workflows and GitHub Actions

### DIFF
--- a/.github/actions/setup-scanner-dependencies/action.yml
+++ b/.github/actions/setup-scanner-dependencies/action.yml
@@ -5,7 +5,7 @@ runs:
   using: "composite"
   steps:
     - name: Install Python and UV
-      uses: astral-sh/setup-uv@bd01e18f51369d5a26f1651c3cb451d3417e3bba # v6.3.1
+      uses: astral-sh/setup-uv@7edac99f961f18b581bbd960d59d049f04c0002f # v6.4.1
       with:
         working-directory: "scanner"
     - name: Set up Just

--- a/.github/actions/setup-tests-dependencies/action.yml
+++ b/.github/actions/setup-tests-dependencies/action.yml
@@ -5,7 +5,7 @@ runs:
   using: "composite"
   steps:
     - name: Install Python and UV
-      uses: astral-sh/setup-uv@bd01e18f51369d5a26f1651c3cb451d3417e3bba # v6.3.1
+      uses: astral-sh/setup-uv@7edac99f961f18b581bbd960d59d049f04c0002f # v6.4.1
       with:
         working-directory: "tests"
     - name: Set up Just

--- a/.github/workflows/clean-caches.yml
+++ b/.github/workflows/clean-caches.yml
@@ -12,6 +12,6 @@ jobs:
     name: Clean Caches
     permissions:
       contents: read
-    uses: JackPlowman/reusable-workflows/.github/workflows/common-clean-caches.yml@446a96a6fee94b9952e9da3049d4353a3387650c # v2025.07.22.02
+    uses: JackPlowman/reusable-workflows/.github/workflows/common-clean-caches.yml@e5bce22fac6a92a28630f44ea3dfb21f817fabbb # v2025.07.22.03
     secrets:
       workflow_github_token: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/clean-caches.yml
+++ b/.github/workflows/clean-caches.yml
@@ -12,6 +12,6 @@ jobs:
     name: Clean Caches
     permissions:
       contents: read
-    uses: JackPlowman/reusable-workflows/.github/workflows/common-clean-caches.yml@f45ce248498fd7d46a13ed80fb9f37e08014baae # v2025.07.20.01
+    uses: JackPlowman/reusable-workflows/.github/workflows/common-clean-caches.yml@446a96a6fee94b9952e9da3049d4353a3387650c # v2025.07.22.02
     secrets:
       workflow_github_token: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -62,7 +62,7 @@ jobs:
       actions: read
       pull-requests: write
       security-events: write
-    uses: JackPlowman/reusable-workflows/.github/workflows/common-code-checks.yml@f45ce248498fd7d46a13ed80fb9f37e08014baae # v2025.07.20.01
+    uses: JackPlowman/reusable-workflows/.github/workflows/common-code-checks.yml@446a96a6fee94b9952e9da3049d4353a3387650c # v2025.07.22.02
     secrets:
       workflow_github_token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -74,7 +74,7 @@ jobs:
     strategy:
       matrix:
         language: [actions, typescript, python]
-    uses: JackPlowman/reusable-workflows/.github/workflows/codeql-analysis.yml@f45ce248498fd7d46a13ed80fb9f37e08014baae # v2025.07.20.01
+    uses: JackPlowman/reusable-workflows/.github/workflows/codeql-analysis.yml@446a96a6fee94b9952e9da3049d4353a3387650c # v2025.07.22.02
     with:
       language: ${{ matrix.language }}
 
@@ -92,7 +92,7 @@ jobs:
       - name: Run Unit Tests
         run: just scanner::unit-test
       - name: SonarCloud Scan
-        uses: SonarSource/sonarqube-scan-action@2500896589ef8f7247069a56136f8dc177c27ccf # v5.2.0
+        uses: SonarSource/sonarqube-scan-action@8c71dc039c2dd71d3821e89a2b58ecc7fee6ced9 # v5.3.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
@@ -118,7 +118,7 @@ jobs:
           RUFF_OUTPUT_FILE: "ruff-results.sarif"
         continue-on-error: true
       - name: Upload Ruff analysis results to GitHub
-        uses: github/codeql-action/upload-sarif@181d5eefc20863364f96762470ba6f862bdef56b # v3.29.2
+        uses: github/codeql-action/upload-sarif@d6bbdef45e766d081b84a2def353b0055f728d3e # v3.29.3
         with:
           sarif_file: scanner/ruff-results.sarif
           wait-for-processing: true
@@ -212,7 +212,7 @@ jobs:
           RUFF_OUTPUT_FILE: "ruff-results.sarif"
         continue-on-error: true
       - name: Upload Ruff analysis results to GitHub
-        uses: github/codeql-action/upload-sarif@181d5eefc20863364f96762470ba6f862bdef56b # v3.29.2
+        uses: github/codeql-action/upload-sarif@d6bbdef45e766d081b84a2def353b0055f728d3e # v3.29.3
         with:
           sarif_file: tests/ruff-results.sarif
           wait-for-processing: true

--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -62,7 +62,7 @@ jobs:
       actions: read
       pull-requests: write
       security-events: write
-    uses: JackPlowman/reusable-workflows/.github/workflows/common-code-checks.yml@446a96a6fee94b9952e9da3049d4353a3387650c # v2025.07.22.02
+    uses: JackPlowman/reusable-workflows/.github/workflows/common-code-checks.yml@e5bce22fac6a92a28630f44ea3dfb21f817fabbb # v2025.07.22.03
     secrets:
       workflow_github_token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -74,7 +74,7 @@ jobs:
     strategy:
       matrix:
         language: [actions, typescript, python]
-    uses: JackPlowman/reusable-workflows/.github/workflows/codeql-analysis.yml@446a96a6fee94b9952e9da3049d4353a3387650c # v2025.07.22.02
+    uses: JackPlowman/reusable-workflows/.github/workflows/codeql-analysis.yml@e5bce22fac6a92a28630f44ea3dfb21f817fabbb # v2025.07.22.03
     with:
       language: ${{ matrix.language }}
 

--- a/.github/workflows/pull-request-tasks.yml
+++ b/.github/workflows/pull-request-tasks.yml
@@ -12,6 +12,6 @@ jobs:
     name: Common Pull Request Tasks
     permissions:
       pull-requests: write
-    uses: JackPlowman/reusable-workflows/.github/workflows/common-pull-request-tasks.yml@f45ce248498fd7d46a13ed80fb9f37e08014baae # v2025.07.20.01
+    uses: JackPlowman/reusable-workflows/.github/workflows/common-pull-request-tasks.yml@446a96a6fee94b9952e9da3049d4353a3387650c # v2025.07.22.02
     secrets:
       workflow_github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pull-request-tasks.yml
+++ b/.github/workflows/pull-request-tasks.yml
@@ -12,6 +12,6 @@ jobs:
     name: Common Pull Request Tasks
     permissions:
       pull-requests: write
-    uses: JackPlowman/reusable-workflows/.github/workflows/common-pull-request-tasks.yml@446a96a6fee94b9952e9da3049d4353a3387650c # v2025.07.22.02
+    uses: JackPlowman/reusable-workflows/.github/workflows/common-pull-request-tasks.yml@e5bce22fac6a92a28630f44ea3dfb21f817fabbb # v2025.07.22.03
     secrets:
       workflow_github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -16,6 +16,6 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
-    uses: JackPlowman/reusable-workflows/.github/workflows/common-sync-labels.yml@f45ce248498fd7d46a13ed80fb9f37e08014baae # v2025.07.20.01
+    uses: JackPlowman/reusable-workflows/.github/workflows/common-sync-labels.yml@446a96a6fee94b9952e9da3049d4353a3387650c # v2025.07.22.02
     secrets:
       workflow_github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -16,6 +16,6 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
-    uses: JackPlowman/reusable-workflows/.github/workflows/common-sync-labels.yml@446a96a6fee94b9952e9da3049d4353a3387650c # v2025.07.22.02
+    uses: JackPlowman/reusable-workflows/.github/workflows/common-sync-labels.yml@e5bce22fac6a92a28630f44ea3dfb21f817fabbb # v2025.07.22.03
     secrets:
       workflow_github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates several dependencies and reusable workflows across multiple GitHub Actions files to ensure the latest versions are used. These changes improve compatibility, security, and functionality. Below is a breakdown of the most important updates:

### Dependency Updates:
* Updated `astral-sh/setup-uv` from version `v6.3.1` to `v6.4.1` in `.github/actions/setup-scanner-dependencies/action.yml` and `.github/actions/setup-tests-dependencies/action.yml`. [[1]](diffhunk://#diff-610971f720595f0388265cdbe9219f6695522574e4cab7966faf1136d8393dbdL8-R8) [[2]](diffhunk://#diff-263e089eb2c5a46d8ce6caaccaaaf176722ae4e8da320d6cd2b779fa67c6ffcdL8-R8)

* Updated `SonarSource/sonarqube-scan-action` from version `v5.2.0` to `v5.3.0` in `.github/workflows/code-checks.yml`.

* Updated `github/codeql-action/upload-sarif` from version `v3.29.2` to `v3.29.3` in `.github/workflows/code-checks.yml`. [[1]](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L121-R121) [[2]](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L215-R215)

### Reusable Workflow Updates:
* Updated references to reusable workflows from `JackPlowman/reusable-workflows` to version `v2025.07.22.02` (hash `446a96a6fee94b9952e9da3049d4353a3387650c`) in the following files:
  - `.github/workflows/clean-caches.yml`
  - `.github/workflows/code-checks.yml` [[1]](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L65-R65) [[2]](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L77-R77)
  - `.github/workflows/pull-request-tasks.yml`
  - `.github/workflows/sync-labels.yml`