### PR TITLE
FORCE_COLOR in deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,6 +20,8 @@ jobs:
     permissions:
       statuses: write
       security-events: write
+    env:
+      FORCE_COLOR: 1
     steps:
       - name: Checkout Repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2


### PR DESCRIPTION
# Pull Request

## Description

This pull request introduces a small change to the deployment workflow configuration. The change sets the `FORCE_COLOR` environment variable to `1` to ensure consistent colored output during the deployment process.

* [`.github/workflows/deploy.yml`](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3R23-R24): Added the `FORCE_COLOR` environment variable under the `env` section in the `jobs` configuration.