### PR TITLE
Exclude Binary Files from Count

### DIFF
--- a/scanner/app/__main__.py
+++ b/scanner/app/__main__.py
@@ -87,6 +87,7 @@ def analyse_repository_files(
                 "__unknown__",
                 "__empty__",
                 "__error__",
+                "__binary__",
             ]:
                 project_summary.add(file_analysis)
 


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes a small update to the `scanner/app/__main__.py` file. The change adds a new category, `"__binary__"`, to the list of file types analyzed in the `analyse_repository_files` function.