### PR TITLE
Fix Schema Validation

### DIFF
--- a/scanner/app/analysis.py
+++ b/scanner/app/analysis.py
@@ -123,11 +123,6 @@ def timeline_analysis(file_path: str, repository_name: str) -> list[Commit]:
 
     first_commit = commits[0]
     first_commit_date = first_commit.committed_datetime.date()
-    logger.warning(
-        "First commit found",
-        first_commit=first_commit.hexsha,
-        first_commit_date=first_commit_date.isoformat(),
-    )
     current_date = date.today()  # noqa: DTZ011
 
     logger.debug(

--- a/tests/schema_validation/output_schema.json
+++ b/tests/schema_validation/output_schema.json
@@ -1,104 +1,78 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://example.com/sloc-count-output.schema.json",
-  "title": "SlocCount Output Schema",
-  "description": "Schema for SlocCount tool output containing repository statistics",
   "type": "object",
-  "required": ["total", "repositories"],
   "properties": {
     "total": {
       "type": "object",
-      "description": "Total statistics across all repositories",
-      "required": ["lines", "files"],
       "properties": {
         "lines": {
           "type": "integer",
-          "minimum": 0,
-          "description": "Total number of lines across all repositories"
+          "minimum": 0
         },
         "files": {
           "type": "integer",
-          "minimum": 0,
-          "description": "Total number of files across all repositories"
+          "minimum": 0
         }
       },
+      "required": ["lines", "files"],
       "additionalProperties": false
     },
     "repositories": {
       "type": "array",
-      "description": "Array of repository statistics",
       "items": {
         "type": "object",
-        "required": ["name", "summary"],
         "properties": {
           "name": {
             "type": "string",
-            "minLength": 1,
-            "description": "Name of the repository"
+            "minLength": 1
           },
           "summary": {
             "type": "object",
-            "description": "Summary statistics for the repository",
-            "required": ["lines", "files"],
             "properties": {
-              "lines": {
+              "total_line_count": {
                 "type": "integer",
-                "minimum": 0,
-                "description": "Number of lines in the repository"
+                "minimum": 0
               },
-              "files": {
+              "total_file_count": {
                 "type": "integer",
-                "minimum": 0,
-                "description": "Number of files in the repository"
+                "minimum": 0
               }
             },
+            "required": ["total_line_count", "total_file_count"],
             "additionalProperties": false
           },
           "commits": {
             "type": "array",
-            "description": "Array of commits in the repository",
             "items": {
               "type": "object",
-              "required": [
-                "commit",
-                "commit_date",
-                "message",
-                "total_files",
-                "total_lines"
-              ],
               "properties": {
-                "commit": {
+                "id": {
                   "type": "string",
-                  "minLength": 1,
-                  "description": "Commit hash"
+                  "pattern": "^[a-f0-9]{40}$"
                 },
-                "commit_date": {
+                "date": {
                   "type": "string",
-                  "format": "date-time",
-                  "description": "Commit date in ISO format"
-                },
-                "message": {
-                  "type": "string",
-                  "description": "Commit message"
+                  "pattern": "^\\d{4}-\\d{2}-\\d{2}$"
                 },
                 "total_files": {
                   "type": "integer",
-                  "minimum": 0,
-                  "description": "Total number of files at this commit"
+                  "minimum": 0
                 },
                 "total_lines": {
                   "type": "integer",
-                  "minimum": 0,
-                  "description": "Total number of lines at this commit"
+                  "minimum": 0
                 }
               },
+              "required": ["id", "date", "total_files", "total_lines"],
               "additionalProperties": false
             }
           }
         },
+        "required": ["name", "summary", "commits"],
         "additionalProperties": false
       }
     }
   },
+  "required": ["total", "repositories"],
   "additionalProperties": false
 }


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes changes to remove unnecessary logging in the timeline analysis function and updates to the schema for validating repository statistics. The most significant changes involve simplifying the JSON schema by removing redundant descriptions and renaming fields for clarity.

### Logging adjustments:
* Removed a warning log in the `timeline_analysis` function that logged the first commit's details, as it was deemed unnecessary. (`scanner/app/analysis.py`, [scanner/app/analysis.pyL126-L130](diffhunk://#diff-b6dee1503025f49b4cc5d31142187ce20d44f714b32e3909ff26d1d8d2c78bb1L126-L130))

### Schema updates:
* Simplified the `output_schema.json` by removing redundant descriptions and required fields for properties, while ensuring all necessary fields are explicitly marked as required. (`tests/schema_validation/output_schema.json`, [tests/schema_validation/output_schema.jsonL3-R76](diffhunk://#diff-3a3c09ea2acf72d134b7171cfdebb3d23e994039d4037c5f3292786b70ade0f3L3-R76))
* Renamed schema fields for clarity:
  - `lines` to `total_line_count`
  - `files` to `total_file_count`
  - `commit` to `id`
  - `commit_date` to `date` (`tests/schema_validation/output_schema.json`, [tests/schema_validation/output_schema.jsonL3-R76](diffhunk://#diff-3a3c09ea2acf72d134b7171cfdebb3d23e994039d4037c5f3292786b70ade0f3L3-R76))
* Updated validation patterns for commit `id` (40-character SHA-1 hash) and `date` (ISO date format). (`tests/schema_validation/output_schema.json`, [tests/schema_validation/output_schema.jsonL3-R76](diffhunk://#diff-3a3c09ea2acf72d134b7171cfdebb3d23e994039d4037c5f3292786b70ade0f3L3-R76))