### PR TITLE
Update Dashboard for Updated Schema

### DIFF
--- a/dashboard/src/components/app-sidebar.tsx
+++ b/dashboard/src/components/app-sidebar.tsx
@@ -38,9 +38,9 @@ export default function AppSidebar({
       case "Z-A":
         return sorted.sort((a, b) => b.name.localeCompare(a.name));
       case "Largest":
-        return sorted.sort((a, b) => b.summary.lines - a.summary.lines);
+        return sorted.sort((a, b) => b.summary.total_line_count - a.summary.total_line_count);
       case "Smallest":
-        return sorted.sort((a, b) => a.summary.lines - b.summary.lines);
+        return sorted.sort((a, b) => a.summary.total_line_count - b.summary.total_line_count);
       case "A-Z":
       default:
         return sorted.sort((a, b) => a.name.localeCompare(b.name));

--- a/dashboard/src/components/app-sidebar.tsx
+++ b/dashboard/src/components/app-sidebar.tsx
@@ -38,9 +38,13 @@ export default function AppSidebar({
       case "Z-A":
         return sorted.sort((a, b) => b.name.localeCompare(a.name));
       case "Largest":
-        return sorted.sort((a, b) => b.summary.total_line_count - a.summary.total_line_count);
+        return sorted.sort(
+          (a, b) => b.summary.total_line_count - a.summary.total_line_count,
+        );
       case "Smallest":
-        return sorted.sort((a, b) => a.summary.total_line_count - b.summary.total_line_count);
+        return sorted.sort(
+          (a, b) => a.summary.total_line_count - b.summary.total_line_count,
+        );
       case "A-Z":
       default:
         return sorted.sort((a, b) => a.name.localeCompare(b.name));

--- a/dashboard/src/components/repository-stats-data-pane.tsx
+++ b/dashboard/src/components/repository-stats-data-pane.tsx
@@ -14,13 +14,13 @@ export default function RepositoryStatsDataPane({
           <div className="bg-gray-100 rounded-lg flex flex-col items-center justify-center h-24 text-lg font-semibold border border-gray-300">
             Total Files:
             <span className="text-2xl font-bold mt-1">
-              {repo.summary.files}
+              {repo.summary.total_file_count}
             </span>
           </div>
           <div className="bg-gray-100 rounded-lg flex flex-col items-center justify-center h-24 text-lg font-semibold border border-gray-300">
             Total Lines:
             <span className="text-2xl font-bold mt-1">
-              {repo.summary.lines}
+              {repo.summary.total_line_count}
             </span>
           </div>
           <div className="bg-gray-100 rounded-lg flex flex-col items-center justify-center h-24 text-lg font-semibold border border-gray-300">

--- a/dashboard/src/types/types.ts
+++ b/dashboard/src/types/types.ts
@@ -1,11 +1,11 @@
-type LinesAndFilesChanged = {
-  lines: number;
-  files: number;
+type RepositorySummary = {
+  total_line_count: number;
+  total_file_count: number;
 };
 
 type RepoStats = {
   name: string;
-  summary: LinesAndFilesChanged;
+  summary: RepositorySummary;
 };
 
 type Data = {
@@ -16,4 +16,4 @@ type Data = {
   repositories: RepoStats[];
 };
 
-export type { Data, LinesAndFilesChanged, RepoStats };
+export type { Data, RepoStats, RepositorySummary };


### PR DESCRIPTION
# Pull Request

## Description

This pull request refactors the naming of properties and types related to repository summaries for improved clarity and consistency. The most important changes include renaming `lines` and `files` to `total_line_count` and `total_file_count`, as well as replacing the `LinesAndFilesChanged` type with `RepositorySummary`.

### Refactoring for clarity and consistency:

* [`dashboard/src/types/types.ts`](diffhunk://#diff-81531abb5d1458384f79438bfe8c874a28dda1706bd7b46e1b1802103b81c461L1-R8): Renamed the `LinesAndFilesChanged` type to `RepositorySummary` and updated its properties from `lines` and `files` to `total_line_count` and `total_file_count`. Updated the `RepoStats` type to use `RepositorySummary` instead of `LinesAndFilesChanged`. [[1]](diffhunk://#diff-81531abb5d1458384f79438bfe8c874a28dda1706bd7b46e1b1802103b81c461L1-R8) [[2]](diffhunk://#diff-81531abb5d1458384f79438bfe8c874a28dda1706bd7b46e1b1802103b81c461L19-R19)

* [`dashboard/src/components/app-sidebar.tsx`](diffhunk://#diff-92e1aa09653c24b3904474245ca2c45681c64ebad04ec9aebfbde04d54ae4b3bL41-R43): Updated sorting logic to use `total_line_count` instead of `lines` for sorting repositories by size.

* [`dashboard/src/components/repository-stats-data-pane.tsx`](diffhunk://#diff-8ebf7cd988825b85a8d48a79796a9482134f478e1703ef1551dac4d6a035f25eL17-R23): Updated the display logic to use `total_line_count` and `total_file_count` instead of `lines` and `files` when rendering repository statistics.
