### PR TITLE
Update License to Licence

### DIFF
--- a/.github/other-configurations/labeller.yml
+++ b/.github/other-configurations/labeller.yml
@@ -25,7 +25,7 @@ markdown:
               [
                 "docs/*.md",
                 "*.md",
-                "LICENSE",
+                "LICENCE",
                 ".github/pull_request_template.md",
               ]
 python:

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Count the number of source lines of code (SLOC) in my projects. As well as a sum
   - [Table of Contents](#table-of-contents)
   - [Architecture](#architecture)
   - [Contributing](#contributing)
-  - [License](#license)
+  - [Licence](#licence)
 
 ## Architecture
 
@@ -20,6 +20,6 @@ Count the number of source lines of code (SLOC) in my projects. As well as a sum
 
 We welcome contributions to the project. Please read the [Contributing Guidelines](docs/CONTRIBUTING.md) for more information.
 
-## License
+## Licence
 
-This project is licensed under the MIT License. See the [LICENSE](LICENSE) file for details.
+This project is licensed under the MIT Licence. See the [LICENCE](LICENCE) file for details.


### PR DESCRIPTION
# Pull Request

## Description

This pull request standardizes the spelling of "License" to "Licence" across the project, updating both documentation and configuration references to match the new naming convention.

Documentation updates:

* Updated all instances of "License" to "Licence" in the `README.md`, including section headers and references to the license file. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L13-R13) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L23-R25)

Configuration updates:

* Changed the file reference from `LICENSE` to `LICENCE` in the `.github/other-configurations/labeller.yml` configuration file.
