### PR TITLE
Add GitHub Workflow Permission Notes

### DIFF
--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -10,7 +10,7 @@ on:
 
 permissions:
   contents: read
-  packages: read
+
 
 env:
   FORCE_COLOR: 1
@@ -20,10 +20,17 @@ jobs:
     name: Common Code Checks
     permissions:
       contents: read
+<<<<<<< HEAD
       actions: read
       pull-requests: write
       security-events: write
     uses: JackPlowman/reusable-workflows/.github/workflows/common-code-checks.yml@a5950751b77827654b888eb6b52a5c7fbca3e4fa # v2025.09.30.01
+=======
+      actions: read # Allow the workflow to read actions metadata
+      pull-requests: write # Allow the workflow to create and modify pull request comments
+      security-events: write # Allow the workflow to upload analysis results
+    uses: JackPlowman/reusable-workflows/.github/workflows/common-code-checks.yml@e77e648233b977246ecdb30836e2360b33acd1d3 # v2025.09.16.01
+>>>>>>> dd2abaa (update)
     secrets:
       workflow_github_token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -31,7 +38,7 @@ jobs:
     name: CodeQL Analysis
     permissions:
       contents: read
-      security-events: write
+      security-events: write # Allow the workflow to upload analysis results
     strategy:
       matrix:
         language: [actions, typescript, python]
@@ -62,8 +69,7 @@ jobs:
     name: Run Python Scanner Lint Checks
     runs-on: ubuntu-latest
     permissions:
-      statuses: write
-      security-events: write
+      security-events: write # Allow the workflow to upload analysis results
     steps:
       - name: Checkout Repository
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
@@ -121,9 +127,6 @@ jobs:
   run-python-scanner-dead-code-checks:
     name: Run Python Scanner Dead Code Checks
     runs-on: ubuntu-latest
-    permissions:
-      statuses: write
-      security-events: write
     steps:
       - name: Checkout Repository
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
@@ -138,9 +141,6 @@ jobs:
   run-python-scanner-lockfile-check:
     name: Run Python Scanner Lockfile Check
     runs-on: ubuntu-latest
-    permissions:
-      statuses: write
-      security-events: write
     steps:
       - name: Checkout Repository
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
@@ -156,8 +156,7 @@ jobs:
     name: Run Python Tests Lint Checks
     runs-on: ubuntu-latest
     permissions:
-      statuses: write
-      security-events: write
+      security-events: write # Allow the workflow to upload analysis results
     steps:
       - name: Checkout Repository
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
@@ -215,9 +214,6 @@ jobs:
   run-python-tests-lockfile-check:
     name: Run Python Tests Lockfile Check
     runs-on: ubuntu-latest
-    permissions:
-      statuses: write
-      security-events: write
     steps:
       - name: Checkout Repository
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
@@ -233,8 +229,7 @@ jobs:
     name: Run TypeScript Dashboard Code Checks
     runs-on: ubuntu-latest
     permissions:
-      statuses: write
-      security-events: write
+      security-events: write # Allow the workflow to upload analysis results
     steps:
       - name: Checkout Repository
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
@@ -259,9 +254,6 @@ jobs:
   run-typescript-dashboard-format-checks:
     name: Run TypeScript Dashboard Format Checks
     runs-on: ubuntu-latest
-    permissions:
-      statuses: write
-      security-events: write
     steps:
       - name: Checkout Repository
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0

--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -11,7 +11,6 @@ on:
 permissions:
   contents: read
 
-
 env:
   FORCE_COLOR: 1
 

--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -20,17 +20,10 @@ jobs:
     name: Common Code Checks
     permissions:
       contents: read
-<<<<<<< HEAD
-      actions: read
-      pull-requests: write
-      security-events: write
-    uses: JackPlowman/reusable-workflows/.github/workflows/common-code-checks.yml@a5950751b77827654b888eb6b52a5c7fbca3e4fa # v2025.09.30.01
-=======
       actions: read # Allow the workflow to read actions metadata
       pull-requests: write # Allow the workflow to create and modify pull request comments
       security-events: write # Allow the workflow to upload analysis results
-    uses: JackPlowman/reusable-workflows/.github/workflows/common-code-checks.yml@e77e648233b977246ecdb30836e2360b33acd1d3 # v2025.09.16.01
->>>>>>> dd2abaa (update)
+    uses: JackPlowman/reusable-workflows/.github/workflows/common-code-checks.yml@a5950751b77827654b888eb6b52a5c7fbca3e4fa # v2025.09.30.01
     secrets:
       workflow_github_token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/pull-request-tasks.yml
+++ b/.github/workflows/pull-request-tasks.yml
@@ -10,7 +10,12 @@ jobs:
   common-pull-request-tasks:
     name: Common Pull Request Tasks
     permissions:
+<<<<<<< HEAD
       pull-requests: write
     uses: JackPlowman/reusable-workflows/.github/workflows/common-pull-request-tasks.yml@a5950751b77827654b888eb6b52a5c7fbca3e4fa # v2025.09.30.01
+=======
+      pull-requests: write # For writing labels and comments on PRs
+    uses: JackPlowman/reusable-workflows/.github/workflows/common-pull-request-tasks.yml@e77e648233b977246ecdb30836e2360b33acd1d3 # v2025.09.16.01
+>>>>>>> dd2abaa (update)
     secrets:
       workflow_github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pull-request-tasks.yml
+++ b/.github/workflows/pull-request-tasks.yml
@@ -15,7 +15,7 @@ jobs:
     uses: JackPlowman/reusable-workflows/.github/workflows/common-pull-request-tasks.yml@a5950751b77827654b888eb6b52a5c7fbca3e4fa # v2025.09.30.01
 =======
       pull-requests: write # For writing labels and comments on PRs
-    uses: JackPlowman/reusable-workflows/.github/workflows/common-pull-request-tasks.yml@e77e648233b977246ecdb30836e2360b33acd1d3 # v2025.09.16.01
+    uses: JackPlowman/reusable-workflows/.github/workflows/common-pull-request-tasks.yml@a5950751b77827654b888eb6b52a5c7fbca3e4fa # v2025.09.30.01
 >>>>>>> dd2abaa (update)
     secrets:
       workflow_github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pull-request-tasks.yml
+++ b/.github/workflows/pull-request-tasks.yml
@@ -10,12 +10,7 @@ jobs:
   common-pull-request-tasks:
     name: Common Pull Request Tasks
     permissions:
-<<<<<<< HEAD
       pull-requests: write
     uses: JackPlowman/reusable-workflows/.github/workflows/common-pull-request-tasks.yml@a5950751b77827654b888eb6b52a5c7fbca3e4fa # v2025.09.30.01
-=======
-      pull-requests: write # For writing labels and comments on PRs
-    uses: JackPlowman/reusable-workflows/.github/workflows/common-pull-request-tasks.yml@a5950751b77827654b888eb6b52a5c7fbca3e4fa # v2025.09.30.01
->>>>>>> dd2abaa (update)
     secrets:
       workflow_github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -15,7 +15,7 @@ jobs:
     name: Configure Labels
     permissions:
       contents: read
-      pull-requests: write
+      pull-requests: write # For writing labels to the repository
     uses: JackPlowman/reusable-workflows/.github/workflows/common-sync-labels.yml@a5950751b77827654b888eb6b52a5c7fbca3e4fa # v2025.09.30.01
     secrets:
       workflow_github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates several GitHub Actions workflow files to clarify and simplify the permissions used in various jobs. The main focus is adding explanatory comments for permissions and removing unnecessary or redundant permission blocks, which helps improve maintainability and security transparency.

**Workflow permissions clarification and cleanup:**

* Added descriptive comments to permission entries in `.github/workflows/code-checks.yml` to clarify why each permission is required [[1]](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L23-R25) [[2]](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L34-R34) [[3]](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L65-R65) [[4]](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L159-R152) [[5]](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L236-R225).
* Removed redundant or unnecessary `statuses: write` permission blocks from several jobs in `.github/workflows/code-checks.yml` to streamline permission usage [[1]](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L124-L126) [[2]](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L141-L143) [[3]](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L218-L220) [[4]](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L262-L264).

**Consistency improvements in other workflows:**

* Added or clarified comments for `pull-requests: write` permission in `.github/workflows/pull-request-tasks.yml` and resolved a merge conflict in the permissions section.
* Added a comment explaining the purpose of `pull-requests: write` in `.github/workflows/sync-labels.yml`.