### PR TITLE
Update Prek Freeze Command

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -107,7 +107,7 @@ prek-update:
 
 # Prek update hooks
 prek-update-hooks:
-    prek autoupdate
+    prek update --freeze
 
 prek-update-additional-dependencies:
     uv run --script https://raw.githubusercontent.com/JackPlowman/update-prek-additional-dependencies/refs/heads/main/update_prek_additional_dependencies.py
@@ -120,4 +120,3 @@ prek-update-additional-dependencies:
 update:
     just pinact-update
     just prek-update
-    just prek-update-additional-dependencies


### PR DESCRIPTION
# Pull Request

## Description

This pull request makes minor updates to the `Justfile` related to the `prek` update workflow. The main changes are to the way `prek` is updated and to the removal of an additional dependencies update step.

- Prek update process:
  * Changed the `prek-update-hooks` command to use `prek update --freeze` instead of `prek autoupdate`, likely to ensure dependencies are frozen during the update process.

- Update workflow:
  * Removed the `prek-update-additional-dependencies` step from the `update` recipe, simplifying the update process.